### PR TITLE
fix: admin reschedule date picker showing Invalid date format

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -490,10 +490,12 @@ def admin_reschedule_slots(
     booking = db.query(Booking).filter_by(id=booking_id, status="confirmed").first()
     if not booking:
         raise HTTPException(status_code=404, detail="Booking not found.")
+    if not date:
+        return HTMLResponse("")
     try:
         target_date = date_type.fromisoformat(date)
     except ValueError:
-        return HTMLResponse("<p class='no-slots'>Invalid date format.</p>")
+        return HTMLResponse("")
     slot_data = _compute_slots_for_type(
         booking.appointment_type, target_date, db,
         destination=booking.location, skip_advance_notice=True,

--- a/app/templates/admin/admin_reschedule.html
+++ b/app/templates/admin/admin_reschedule.html
@@ -20,7 +20,9 @@
       hx-get="/admin/bookings/{{ booking.id }}/reschedule/slots"
       hx-target="#slot-area"
       hx-swap="innerHTML"
-      hx-trigger="change">
+      hx-trigger="change[this.value]"
+      hx-sync="this:replace"
+      name="date">
   </label>
   <div id="slot-area" style="margin-top:1rem;"></div>
   <div id="confirmation-section" style="display:none;margin-top:1rem;">


### PR DESCRIPTION
## Summary

- Same empty-`change`-event bug as PR #15, but in the admin reschedule flow
- The admin date input was also missing `name="date"`, so HTMX couldn't serialize the date value as a query parameter at all — every request landed with `date=""`, triggering the error

## Changes

- `admin/admin_reschedule.html`: add `name="date"`, `hx-trigger="change[this.value]"`, `hx-sync="this:replace"`
- `admin.py` `admin_reschedule_slots`: return empty HTML (not error message) for missing/invalid date

## Test plan

- [ ] Go to Admin → Bookings → Reschedule on any booking
- [ ] Confirm no error appears on page load
- [ ] Select a date — confirm time slots appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)