### PR TITLE
fix: HTMX trigger filter must return boolean not truthy string

### DIFF
--- a/app/templates/admin/admin_reschedule.html
+++ b/app/templates/admin/admin_reschedule.html
@@ -20,7 +20,7 @@
       hx-get="/admin/bookings/{{ booking.id }}/reschedule/slots"
       hx-target="#slot-area"
       hx-swap="innerHTML"
-      hx-trigger="change[this.value]"
+      hx-trigger="change[this.value !== '']"
       hx-sync="this:replace"
       name="date">
   </label>

--- a/app/templates/booking/reschedule.html
+++ b/app/templates/booking/reschedule.html
@@ -29,7 +29,7 @@
     hx-get="/reschedule/{{ token }}/slots"
     hx-target="#slot-area"
     hx-swap="innerHTML"
-    hx-trigger="change[this.value]"
+    hx-trigger="change[this.value !== '']"
     hx-sync="this:replace"
     name="date">
 </div>


### PR DESCRIPTION
## What was wrong

PR #15 and #16 added `hx-trigger="change[this.value]"` to prevent HTMX from firing when the date input is empty. This stopped the \"Invalid date format\" on page load — but it also stopped HTMX from **ever** firing, even with a valid date.

**Root cause**: HTMX evaluates trigger filters as `result !== true`. An expression must return exactly boolean `true` to pass. `this.value` returns a string like `"2026-04-25"`, which is truthy but **not** `=== true`, so HTMX suppressed every event. Zero slot requests reached the server.

## Fix

`change[this.value !== '']` returns a proper boolean — `true` when a date is selected, `false` when empty. Both the public and admin reschedule date pickers updated.

## Test plan

- [ ] Admin: Bookings → Reschedule → select a date → time slots appear
- [ ] Public reschedule link → select a date → time slots appear
- [ ] Neither page shows \"Invalid date format\" on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)