### PR TITLE
fix: show custom time section via JS listener not hx-on

### DIFF
--- a/app/templates/admin/admin_reschedule.html
+++ b/app/templates/admin/admin_reschedule.html
@@ -22,7 +22,6 @@
       hx-swap="innerHTML"
       hx-trigger="change[this.value !== '']"
       hx-sync="this:replace"
-      hx-on::after-swap="document.getElementById('custom-time-section').style.display='block';document.getElementById('custom-time').value='';"
       name="date">
   </label>
   <div id="slot-area" style="margin-top:1rem;"></div>
@@ -49,6 +48,12 @@
 </div>
 
 <script>
+document.getElementById('reschedule-date').addEventListener('change', function() {
+  if (this.value) {
+    document.getElementById('custom-time-section').style.display = 'block';
+    document.getElementById('custom-time').value = '';
+  }
+});
 function selectRescheduleSlot(value, display) {
   var date = document.getElementById('reschedule-date').value;
   document.getElementById('confirm-datetime').value = date + 'T' + value + ':00';


### PR DESCRIPTION
## Summary

`hx-on::after-swap` silently did nothing in HTMX 1.9 — the custom time override section never appeared. Replaced with a plain `addEventListener('change', ...)` on the date input, which reliably shows the section when a date is selected.

## Test plan

- [ ] Select a date on the admin reschedule page
- [ ] Confirm "Force a specific time" section appears below the slot buttons
- [ ] Enter 6:30 PM → Use This Time → Confirm Reschedule works

🤖 Generated with [Claude Code](https://claude.com/claude-code)