### PR TITLE
fix: filter past time slots when admin bypasses advance notice

### DIFF
--- a/app/routers/slots.py
+++ b/app/routers/slots.py
@@ -165,6 +165,8 @@ def _compute_slots_for_type(
     )
     if not skip_advance_notice:
         slots = filter_by_advance_notice(slots, target_date, min_advance, now_local)
+    else:
+        slots = filter_by_advance_notice(slots, target_date, 0, now_local)
 
     # Group showings: inject same-type booking start times back as candidates,
     # then post-filter by concurrent count.

--- a/tests/test_admin_reschedule.py
+++ b/tests/test_admin_reschedule.py
@@ -211,8 +211,13 @@ def test_admin_reschedule_slots_bypass_advance_notice():
     db.commit()
     db.close()
 
-    # 2025-09-15 is a Monday
-    response = client.get(f"/admin/bookings/{booking_id}/reschedule/slots?date=2025-09-15")
+    # Find the next Monday at least 1 day from today so the 0h past-filter doesn't remove all slots
+    from datetime import date, timedelta
+    today = date.today()
+    days_ahead = (0 - today.weekday()) % 7 or 7
+    next_monday = (today + timedelta(days=days_ahead)).isoformat()
+
+    response = client.get(f"/admin/bookings/{booking_id}/reschedule/slots?date={next_monday}")
     assert response.status_code == 200
     # Should have slot buttons, not just "no available times"
     assert "slot-btn" in response.text


### PR DESCRIPTION
## Summary

`skip_advance_notice=True` (used by admin reschedule) bypassed `filter_by_advance_notice` entirely, including the logic that removes slots already in the past. This caused past slots to appear in the admin reschedule picker.

Fix: when skipping advance notice, still run the filter with `min_advance_hours=0` — removes anything before now, allows anything in the future.

## Test plan

- [ ] Admin reschedule on a booking: select today's date
- [ ] Confirm only future time slots appear (no past times shown)
- [ ] Slots for tomorrow still show the full day

🤖 Generated with [Claude Code](https://claude.com/claude-code)