### PR TITLE
fix: return default 30-min drive time on Maps API failure

### DIFF
--- a/app/services/drive_time.py
+++ b/app/services/drive_time.py
@@ -6,6 +6,7 @@ from app.config import get_settings
 
 MAPS_DISTANCE_MATRIX_URL = "https://maps.googleapis.com/maps/api/distancematrix/json"
 CACHE_TTL_DAYS = 30
+DEFAULT_DRIVE_TIME_MINUTES = 30
 
 
 def get_drive_time(origin: str, destination: str, db) -> int:
@@ -13,7 +14,8 @@ def get_drive_time(origin: str, destination: str, db) -> int:
 
     Checks DriveTimeCache first. Calls Google Maps Distance Matrix API if
     the cache entry is missing or older than 30 days. Returns 0 if the API
-    key is not configured or the request fails.
+    key is not configured. Returns DEFAULT_DRIVE_TIME_MINUTES if the API
+    call fails or returns a non-OK status.
     """
     from app.models import DriveTimeCache
 
@@ -47,11 +49,11 @@ def get_drive_time(origin: str, destination: str, db) -> int:
         data = resp.json()
         element = data["rows"][0]["elements"][0]
         if element["status"] != "OK":
-            return 0
+            return DEFAULT_DRIVE_TIME_MINUTES
         duration_seconds = element["duration"]["value"]
         drive_minutes = (duration_seconds + 59) // 60  # round up to nearest minute
     except Exception:
-        return 0
+        return DEFAULT_DRIVE_TIME_MINUTES
 
     # Upsert cache
     if cache_entry:

--- a/tests/test_drive_time.py
+++ b/tests/test_drive_time.py
@@ -60,14 +60,14 @@ def test_get_drive_time_uses_cache_on_second_call():
     assert mock_get.call_count == 1  # Only called once; second call used cache
 
 
-def test_get_drive_time_returns_zero_on_maps_api_failure():
-    from app.services.drive_time import get_drive_time
+def test_get_drive_time_returns_default_on_maps_api_failure():
+    from app.services.drive_time import get_drive_time, DEFAULT_DRIVE_TIME_MINUTES
     db = make_db()
     with patch("app.services.drive_time.get_settings") as mock_settings, \
          patch("app.services.drive_time.httpx.get", side_effect=Exception("network error")):
         mock_settings.return_value.google_maps_api_key = "fake-key"
         result = get_drive_time("123 Main St", "456 Oak Ave", db)
-    assert result == 0
+    assert result == DEFAULT_DRIVE_TIME_MINUTES
 
 
 def test_get_drive_time_refreshes_stale_cache():


### PR DESCRIPTION
## Summary

- Drive time API failures previously returned 0 minutes, silently disabling drive-time slot protection
- Adds `DEFAULT_DRIVE_TIME_MINUTES = 30` constant; both failure paths (`except Exception` and non-OK Maps API status) now return this instead of 0
- Updates the affected test to assert against the new default behaviour

## Root cause

A lead was able to book a showing at 4072 Creekrun Circle (Buford) 15 minutes after an appointment ending at 9820 Alger Trce (Johns Creek) — a ~45-minute drive. The Google Maps API call failed silently, returned 0, and the window was never trimmed.

## Test plan

- [x] `tests/test_drive_time.py` — all 5 pass, including updated failure-case assertion
- [x] Full suite — 167 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)