### PR TITLE
refactor: extract service layer, dedupe logic, add logging and indexes

### DIFF
--- a/ARCHITECTURE_REVIEW.md
+++ b/ARCHITECTURE_REVIEW.md
@@ -1,0 +1,145 @@
+# Architecture Review — BookingAssistant
+
+*Review date: June 2026. Written as a deep-dive onboarding review: architecture reconstruction, data-flow analysis, problem inventory, and the refactoring strategy applied in the accompanying change set.*
+
+---
+
+## 1. System overview
+
+A single-tenant appointment booking system. One owner, many guests. FastAPI monolith, server-rendered Jinja2 templates with HTMX for partial updates, SQLite for persistence, Google Calendar as the availability/event backend, Resend for transactional email, Google Maps Distance Matrix for drive-time buffers, Alobar ID (Authentik OIDC) for admin auth.
+
+```
+                        ┌──────────────────────────────────────────────┐
+                        │                  FastAPI app                 │
+  Guest (HTMX) ───────▶ │  routers/booking  routers/slots  (public)    │
+  Owner (browser) ────▶ │  routers/admin    routers/auth   (admin)     │
+                        │        │                                     │
+                        │        ▼                                     │
+                        │  services/  slots · scheduling · booking ·   │
+                        │             availability · calendar ·        │
+                        │             drive_time · email · timeutils   │
+                        │        │                                     │
+                        │        ▼                                     │
+                        │  models + database (SQLite, manual schema)   │
+                        └───────┬──────────┬──────────┬────────────────┘
+                                ▼          ▼          ▼
+                        Google Calendar  Resend   Google Maps
+                        (freebusy/events) (email)  (Distance Matrix)
+```
+
+### Layers (post-refactor)
+
+| Layer | Modules | Responsibility |
+|---|---|---|
+| HTTP | `app/routers/*` | Parse/validate requests, call services, render templates. No business logic. |
+| Domain services | `app/services/slots.py`, `scheduling.py`, `booking.py`, `availability.py` | Slot computation, booking lifecycle (create/cancel/reschedule), drive-time blocks. |
+| Integration services | `app/services/calendar.py`, `drive_time.py`, `email.py` | Wrap Google Calendar, Maps, Resend. Normalize external data to naive-UTC dicts/tuples. |
+| Cross-cutting | `app/dependencies.py`, `services/timeutils.py`, `templating.py`, `limiter.py`, `config.py` | Settings access, CSRF, auth guard, timezone conversion, shared Jinja env, rate limiting. |
+| Persistence | `app/models.py`, `app/database.py` | SQLAlchemy models, engine, manual migrations in `init_db()`. |
+
+### Datetime convention (load-bearing, previously implicit)
+
+The whole system runs on **naive datetimes in two frames**:
+
+- **Naive local** (owner's configured timezone, a DB setting): bookings, availability rules, blocked periods, everything shown to users.
+- **Naive UTC**: everything crossing the Google Calendar / webcal boundary.
+
+`services/timeutils.py` is now the single conversion point (`utc_to_local`, `local_to_utc`, `local_day_bounds_utc`, `get_timezone`). Before the refactor this conversion idiom (`.replace(tzinfo=...).astimezone(...).replace(tzinfo=None)`) was hand-rolled in 12+ places across three routers — the highest-risk duplication in the codebase, because a one-sided mistake silently shifts every slot by the UTC offset (a bug of exactly this shape was fixed in March 2026 per the project history).
+
+---
+
+## 2. Complete data flows
+
+### Public booking (the critical path)
+
+1. `GET /` → active, non-admin appointment types → booking page.
+2. Guest picks type + date → HTMX `GET /slots?type_id&date` → `services.slots.compute_slots_for_type()`:
+   - Load availability rules (type-specific rules override global ones), blocked periods, settings.
+   - Compute the local day's UTC bounds; fetch Google freebusy for the type's calendar plus configured conflict calendars; fetch webcal/ICS feeds; all converted to naive local.
+   - *Calendar-window mode*: only events exactly matching a configured title open windows; everything else on that calendar is busy; fails closed if no match.
+   - Subtract blocked periods and busy intervals from rule windows; intersect with calendar windows; trim window starts by drive time from the preceding event's location (Maps API, 30-day DB cache).
+   - Split windows into 15-minute-aligned start times; apply advance-notice cutoff.
+   - *Group showings* (`max_concurrent > 1`): re-inject already-booked start times (Google freebusy merges adjacent events, so they can't be un-blocked interval-wise), then filter by overlap count.
+3. Guest submits → `POST /book` (rate-limited, CSRF-checked): re-validate, count overlapping confirmed bookings against `max_concurrent` (race-condition guard), insert `Booking` with a UUID reschedule token.
+4. Post-commit, best-effort side effects: owner calendar event → drive-time BLOCK events before/after (IDs stored on the booking for later cleanup) → guest confirmation + admin alert emails (templates editable in admin, fall back to trusted defaults on bad placeholders).
+
+### Reschedule / cancel
+
+Token-addressed (`/reschedule/{token}`, `/cancel/{token}`), no login. `services.scheduling.perform_reschedule()` ordering guards integrity: create new calendar event (fatal on failure — booking unchanged) → delete old event (non-fatal) → update DB → email (non-fatal). Cancel: delete event + drive-time blocks (non-fatal) → email → mark cancelled. Admin reschedule/cancel reuse the same service functions; admin inspection booking uses the narrower `compute_inspection_slots()` (own calendar only, ad-hoc destination for drive time).
+
+### Auth
+
+Admin: OIDC via Authentik (`/login` → callback sets `session["user_sub"]`); `require_admin` raises → exception handler redirects to `/login`. Guests: unauthenticated; capability URLs via reschedule tokens.
+
+---
+
+## 3. Problem inventory
+
+### 3.1 Bad architecture decisions
+
+| # | Finding | Severity | Status |
+|---|---|---|---|
+| A1 | **Business logic lived in routers and was imported across routers as private functions.** `app.routers.admin` imported `_compute_slots_for_type` from `app.routers.slots` and `_delete_drive_time_events`/`_perform_reschedule` from `app.routers.booking`. Routers were the de-facto domain layer; "private" helpers were public API. | High | **Fixed** — extracted to `services/slots.py` and `services/scheduling.py`; routers are thin HTTP adapters. |
+| A2 | **~25 bare `except Exception: pass` blocks and zero logging in the entire application.** "Non-fatal" is the right *policy* for calendar/email side effects, but with no logs, a dead refresh token or Resend outage is indistinguishable from success. The booking confirms; the owner's calendar silently stops updating. | High | **Fixed** — every swallow site now logs a warning with traceback; failure policy unchanged. |
+| A3 | **Settings split across three stores with per-key queries.** Env vars (`config.py`), DB `Setting` key-value rows, and some keys (`resend_api_key`, `from_email`, `timezone`) in *both* with fallback. A booking request issues ~10 separate `Setting` queries. | Medium | Partially addressed (`get_email_config`, `get_conflict_calendars`, `get_timezone` consolidate the multi-key reads). Roadmap: one `load_settings(db)` read per request. |
+| A4 | **Manual schema migrations** via PRAGMA loops in `init_db()`. Works, but column definitions are duplicated between `models.py` and `database.py`, and there's no down-migration or history. | Medium | Accepted for now (house pattern, documented in CLAUDE.md). Roadmap: Alembic. |
+| A5 | **Test suite mocks router-module internals** (`patch("app.routers.slots.datetime")`, `_build_free_windows`, …) rather than integration boundaries, so any module reorganization breaks tests that still pass functionally. | Medium | Patch targets updated to the new layout; structural coupling remains. Roadmap: fake `CalendarService` fixture + clock injection. |
+| A6 | Per-router `Jinja2Templates` instances with divergent filter/global registration (admin had `enumerate`, booking had `csrf_token`, slots had neither). | Low | **Fixed** — single shared env in `app/templating.py`. |
+
+### 3.2 Duplicate logic (found → resolved)
+
+| Duplication | Was | Now |
+|---|---|---|
+| Admin `inspection_slots` re-implemented ~80 lines of the slot engine (day bounds, freebusy, localization, drive-time trim, advance notice) | 2 copies | `compute_inspection_slots()` built from the same building blocks; the *intentional* differences (no conflict calendars/webcal/window/group capacity) are now documented in its docstring instead of being implicit in a fork |
+| Naive UTC↔local conversion idiom | 12+ inline copies | `services/timeutils.py` |
+| `CalendarService(settings.google_client_id, settings.google_client_secret, settings.google_redirect_uri)` 5-line construction | 8 copies | `build_calendar_service(settings)` |
+| Email template render + fallback try/except with identical kwargs | 3×2 copies | `_render()` + `_send()` in `services/email.py` |
+| `conflict_calendars` JSON parse with error swallow | 3 copies | `get_conflict_calendars()` / `set_conflict_calendars()` |
+| Notification config triple-read (`notifications_enabled`, `resend_api_key`, `from_email`) | 4 copies | `get_email_config()` → `EmailConfig` named tuple |
+| Booking cancel calendar cleanup (event + drive-time blocks) in public and admin routes | 2 copies | `delete_booking_calendar_events()` |
+| Token-error page rendering, booking-by-token lookup, reschedule form re-render contexts in `routers/booking.py` | 4–5 copies | `_token_error()`, `_booking_by_token()`, `_reschedule_form()` |
+| Photo save/delete file handling in create + update appointment type | 2 copies | `_save_photo()` / `_delete_photo()` |
+
+### 3.3 Performance bottlenecks
+
+| # | Finding | Status |
+|---|---|---|
+| P1 | **Webcal feeds fetched synchronously on every `/slots` request, per feed, with no caching** (10 s timeout each). Google freebusy + events calls likewise sequential. A guest clicking through dates pays the full network cost every click. This is the dominant latency term. | Open (roadmap §5.2) — needs a short-TTL busy-interval cache; left out of this pass because caching changes observable freshness behavior. |
+| P2 | No indexes on `bookings` despite every hot query filtering on `status` + `start_datetime` (+ `appointment_type_id` for conflict/capacity checks). Full table scans on the booking race-condition guard. | **Fixed** — composite indexes `(status, start_datetime)` and `(appointment_type_id, status, start_datetime)`, created idempotently for existing DBs. |
+| P3 | `bookings_page` does an O(n²) pairwise overlap scan to badge group showings. Bounded today (upcoming + 50 past) — fine at this scale; a sort-and-sweep per type is the fix if listings grow. | Accepted (documented). |
+| P4 | Slot computation loads *all* `BlockedPeriod` rows and all active rules per request rather than date-filtered. Negligible now; trivially filterable later. | Accepted. |
+
+### 3.4 Scalability risks
+
+- **S1 — SQLite + single process** is the architecture's stated scope (single owner, Coolify volume). The real risk isn't throughput, it's the **booking race**: the `max_concurrent` overlap check and the insert are not atomic. Two simultaneous guests can both pass the count. SQLite's write serialization makes the window tiny, but moving to Postgres/multi-worker without adding a transactional guard (`SELECT … FOR UPDATE` or a unique constraint on `(appointment_type_id, start_datetime)` for `max_concurrent=1` types) would widen it.
+- **S2 — Blocking I/O in request handlers.** Acceptable under FastAPI's threadpool for sync routes at this traffic; the latency cost (P1) bites before the concurrency cost does.
+- **S3 — Filesystem session/upload coupling**: uploads on a container volume, sessions in signed cookies — both fine single-node, both assumptions to revisit if ever multi-node.
+
+### 3.5 Maintainability issues
+
+- **M1 — Silent failure** (A2): fixed; this was the most dangerous one operationally.
+- **M2 — 950-line admin router** mixing nine concerns. Reduced and de-duplicated in place; splitting into `admin/` sub-routers is the next step if it keeps growing.
+- **M3 — Stringly-typed booleans** from HTML forms (`requires_drive_time == "true"`), JSON-in-TEXT columns with property wrappers (`custom_fields`, `rental_requirements`). Idiomatic enough for the stack; documented so it isn't "fixed" into a behavior change casually.
+- **M4 — README drift**: README still describes "single-password admin authentication" although auth is OIDC since May 2026.
+
+---
+
+## 4. What this change set did (behavior-preserving)
+
+1. **Service-layer extraction** — `services/slots.py` (slot engine: `compute_slots_for_type`, `compute_inspection_slots`), `services/scheduling.py` (`perform_reschedule`, `create_drive_time_blocks`, `delete_drive_time_events`, `delete_booking_calendar_events`). Routers now contain HTTP concerns only; no router imports another router.
+2. **Single-point utilities** — `services/timeutils.py` (timezone frames), `build_calendar_service()` (client construction), `app/templating.py` (shared Jinja env), `get_conflict_calendars` / `get_email_config` (settings access).
+3. **Observability** — module loggers everywhere side effects can fail; every previously-silent `except` now records a warning with traceback. Failure *policy* (non-fatal best-effort) is unchanged.
+4. **Email service dedup** — one render-with-fallback helper, one send helper.
+5. **Indexes** — composite booking indexes in both the ORM metadata (fresh DBs) and `init_db()` (existing DBs), following the project's idempotent-migration pattern.
+6. **Tests** — all patch targets updated to the new module layout; assertions untouched. Suite: 163 passed, 17 skipped — identical to the pre-refactor baseline.
+
+Deliberately **not** done, to honor "do not change functionality": busy-interval caching (changes freshness semantics), async I/O conversion, transactional booking guard (changes conflict behavior under race), Alembic migration (deployment-affecting), README fixes beyond scope, and the O(n²) admin badge scan (bounded, correct).
+
+## 5. Refactoring roadmap (recommended order)
+
+1. **Short-TTL cache for busy intervals + webcal feeds** (P1) — biggest user-visible win; cache per `(calendar_id, date)` for 30–60 s in-process; invalidate on booking creation.
+2. **Transactional booking guard** (S1) — wrap overlap-check + insert in `BEGIN IMMEDIATE` (SQLite) so the race window closes; prerequisite for any move off SQLite.
+3. **Single settings load per request** (A3) — one query, typed accessor object; removes ~10 queries/request and the env/DB fallback ambiguity.
+4. **Test seams** (A5) — inject a clock and a calendar gateway fixture instead of `patch(...datetime)`; makes future moves free.
+5. **Alembic** (A4) — retire the PRAGMA loops; the current pattern is one `ALTER`-typo away from a broken prod boot.
+6. **Split `routers/admin.py`** (M2) into `admin/{appointment_types,availability,bookings,settings,google,inspection}.py` when it next grows.

--- a/app/database.py
+++ b/app/database.py
@@ -76,6 +76,18 @@ def init_db():
             "ON bookings (reschedule_token)"
         ))
 
+        # Indexes for the hot booking queries (dashboard, bookings list,
+        # conflict/group-capacity checks). IF NOT EXISTS keeps this idempotent
+        # for databases created before the indexes were introduced.
+        conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS ix_bookings_status_start "
+            "ON bookings (status, start_datetime)"
+        ))
+        conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS ix_bookings_type_status_start "
+            "ON bookings (appointment_type_id, status, start_datetime)"
+        ))
+
         existing_ar = {row[1] for row in conn.execute(text("PRAGMA table_info(availability_rules)"))}
         for col, definition in [
             ("appointment_type_id", "INTEGER REFERENCES appointment_types(id)"),

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,5 +1,7 @@
 import hmac
+import json
 import secrets
+from typing import NamedTuple
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse
@@ -31,6 +33,39 @@ def set_setting(db: Session, key: str, value: str):
     else:
         db.add(Setting(key=key, value=value))
     db.commit()
+
+
+def get_conflict_calendars(db: Session) -> list[dict]:
+    """Return the configured extra conflict calendars ([{type, id, name}, ...])."""
+    raw = get_setting(db, "conflict_calendars", "[]")
+    try:
+        cals = json.loads(raw)
+    except (ValueError, TypeError):
+        return []
+    return cals if isinstance(cals, list) else []
+
+
+def set_conflict_calendars(db: Session, cals: list[dict]) -> None:
+    set_setting(db, "conflict_calendars", json.dumps(cals))
+
+
+class EmailConfig(NamedTuple):
+    enabled: bool
+    api_key: str
+    from_email: str
+
+    @property
+    def can_send(self) -> bool:
+        return self.enabled and bool(self.api_key)
+
+
+def get_email_config(db: Session, settings) -> EmailConfig:
+    """Return notification settings, falling back to env-derived defaults."""
+    return EmailConfig(
+        enabled=get_setting(db, "notifications_enabled", "true") == "true",
+        api_key=get_setting(db, "resend_api_key", settings.resend_api_key),
+        from_email=get_setting(db, "from_email", settings.from_email),
+    )
 
 
 def get_csrf_token(request: Request) -> str:

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from datetime import datetime
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.database import Base
 
@@ -88,6 +88,11 @@ class BlockedPeriod(Base):
 
 class Booking(Base):
     __tablename__ = "bookings"
+    __table_args__ = (
+        # Match the names used in database.init_db() so existing DBs converge.
+        Index("ix_bookings_status_start", "status", "start_datetime"),
+        Index("ix_bookings_type_status_start", "appointment_type_id", "status", "start_datetime"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     appointment_type_id: Mapped[int] = mapped_column(ForeignKey("appointment_types.id"))

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,26 +1,42 @@
 import json
+import logging
 import os
 import uuid
 from datetime import datetime, timedelta
 from datetime import date as date_type
+from urllib.parse import urlparse
+
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import HTMLResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
 from app.config import get_settings
 from app.database import get_db
-from app.dependencies import get_setting, require_admin, require_csrf, set_setting
+from app.dependencies import (
+    get_conflict_calendars,
+    get_email_config,
+    get_setting,
+    require_admin,
+    require_csrf,
+    set_conflict_calendars,
+    set_setting,
+)
 from app.models import AppointmentType, AvailabilityRule, BlockedPeriod, Booking
-from app.routers.booking import _delete_drive_time_events
-from app.routers.slots import _compute_slots_for_type
-from app.services.calendar import CalendarService
+from app.services import email
+from app.services.booking import cancel_booking, create_booking
+from app.services.calendar import build_calendar_service
+from app.services.scheduling import (
+    create_drive_time_blocks,
+    delete_booking_calendar_events,
+    perform_reschedule,
+)
+from app.services.slots import compute_inspection_slots, compute_slots_for_type
+from app.services.timeutils import get_timezone, local_to_utc
+from app.templating import templates
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin")
-templates = Jinja2Templates(directory="app/templates")
-templates.env.filters["enumerate"] = enumerate
-from app.dependencies import get_csrf_token as _get_csrf_token
-templates.env.globals["csrf_token"] = _get_csrf_token
 AuthDep = Depends(require_admin)
 
 
@@ -28,7 +44,6 @@ def _validate_url(url: str) -> str:
     """Return the URL only if its scheme is http or https; blank it otherwise."""
     if not url:
         return ""
-    from urllib.parse import urlparse
     scheme = urlparse(url).scheme.lower()
     return url if scheme in ("http", "https") else ""
 
@@ -39,6 +54,32 @@ def _flash(request: Request, message: str, type: str = "success"):
 
 def _get_flash(request: Request):
     return request.session.pop("flash", None)
+
+
+def _save_photo(photo: UploadFile, contents: bytes) -> str:
+    """Store an uploaded photo under a random name; return the filename."""
+    ext = os.path.splitext(photo.filename)[1].lower() or ".jpg"
+    filename = f"{uuid.uuid4().hex}{ext}"
+    upload_dir = get_settings().upload_dir
+    os.makedirs(upload_dir, exist_ok=True)
+    with open(os.path.join(upload_dir, filename), "wb") as f:
+        f.write(contents)
+    return filename
+
+
+def _delete_photo(filename: str) -> None:
+    if not filename:
+        return
+    path = os.path.join(get_settings().upload_dir, filename)
+    if os.path.isfile(path):
+        os.remove(path)
+
+
+def _parse_rental_requirements(raw_json: str) -> list:
+    try:
+        return json.loads(raw_json)
+    except (json.JSONDecodeError, ValueError):
+        return []
 
 
 # ---------- Dashboard ----------
@@ -110,13 +151,14 @@ async def create_appt_type(
     _=AuthDep,
     _csrf_ok: None = Depends(require_csrf),
 ):
+    is_admin_initiated = admin_initiated == "true"
     t = AppointmentType(
         name=name, description=description, duration_minutes=duration_minutes,
         buffer_before_minutes=buffer_before_minutes, buffer_after_minutes=buffer_after_minutes,
         calendar_id=calendar_id, color=color, location=location, show_as=show_as,
         visibility=visibility, owner_event_title=owner_event_title, guest_event_title=guest_event_title,
-        admin_initiated=(admin_initiated == "true"),
-        requires_drive_time=True if (admin_initiated == "true") else (requires_drive_time == "true"),
+        admin_initiated=is_admin_initiated,
+        requires_drive_time=is_admin_initiated or requires_drive_time == "true",
         calendar_window_enabled=(calendar_window_enabled == "true"),
         calendar_window_title=calendar_window_title,
         calendar_window_calendar_id=calendar_window_calendar_id,
@@ -127,22 +169,12 @@ async def create_appt_type(
         active=True,
     )
     t.custom_fields = []
-    try:
-        t.rental_requirements = json.loads(rental_requirements_json)
-    except (json.JSONDecodeError, ValueError):
-        t.rental_requirements = []
+    t.rental_requirements = _parse_rental_requirements(rental_requirements_json)
     db.add(t)
     db.commit()
     db.refresh(t)
     if photo and photo.filename:
-        from app.config import get_settings as _gs
-        ext = os.path.splitext(photo.filename)[1].lower() or ".jpg"
-        filename = f"{uuid.uuid4().hex}{ext}"
-        upload_dir = _gs().upload_dir
-        os.makedirs(upload_dir, exist_ok=True)
-        with open(os.path.join(upload_dir, filename), "wb") as f:
-            f.write(await photo.read())
-        t.photo_filename = filename
+        t.photo_filename = _save_photo(photo, await photo.read())
         db.commit()
     _flash(request, f"Created '{name}'.")
     return RedirectResponse("/admin/appointment-types", status_code=302)
@@ -194,47 +226,34 @@ async def update_appt_type(
 ):
     t = db.query(AppointmentType).filter_by(id=type_id).first()
     if t:
-        t.name = name; t.description = description; t.duration_minutes = duration_minutes
+        t.name = name
+        t.description = description
+        t.duration_minutes = duration_minutes
         t.buffer_before_minutes = buffer_before_minutes
         t.buffer_after_minutes = buffer_after_minutes
-        t.calendar_id = calendar_id; t.color = color
-        t.location = location; t.show_as = show_as; t.visibility = visibility
+        t.calendar_id = calendar_id
+        t.color = color
+        t.location = location
+        t.show_as = show_as
+        t.visibility = visibility
         t.owner_event_title = owner_event_title
         t.guest_event_title = guest_event_title
-        t.admin_initiated = (admin_initiated == "true")
-        if t.admin_initiated:
-            t.requires_drive_time = True
-        else:
-            t.requires_drive_time = (requires_drive_time == "true")
-        t.calendar_window_enabled = (calendar_window_enabled == "true")
+        t.admin_initiated = admin_initiated == "true"
+        t.requires_drive_time = t.admin_initiated or requires_drive_time == "true"
+        t.calendar_window_enabled = calendar_window_enabled == "true"
         t.calendar_window_title = calendar_window_title
         t.calendar_window_calendar_id = calendar_window_calendar_id
         t.listing_url = _validate_url(listing_url)
         t.rental_application_url = _validate_url(rental_application_url)
-        t.owner_reminders_enabled = (owner_reminders_enabled == "true")
+        t.owner_reminders_enabled = owner_reminders_enabled == "true"
         t.max_concurrent = max(1, max_concurrent)
-        try:
-            t.rental_requirements = json.loads(rental_requirements_json)
-        except (json.JSONDecodeError, ValueError):
-            t.rental_requirements = []
-        from app.config import get_settings as _gs
-        upload_dir = _gs().upload_dir
-        if remove_photo == "true" and (t.photo_filename or ""):
-            old_path = os.path.join(upload_dir, t.photo_filename)
-            if os.path.isfile(old_path):
-                os.remove(old_path)
+        t.rental_requirements = _parse_rental_requirements(rental_requirements_json)
+        if remove_photo == "true" and t.photo_filename:
+            _delete_photo(t.photo_filename)
             t.photo_filename = ""
         elif photo and photo.filename:
-            if t.photo_filename or "":
-                old_path = os.path.join(upload_dir, t.photo_filename)
-                if os.path.isfile(old_path):
-                    os.remove(old_path)
-            ext = os.path.splitext(photo.filename)[1].lower() or ".jpg"
-            filename = f"{uuid.uuid4().hex}{ext}"
-            os.makedirs(upload_dir, exist_ok=True)
-            with open(os.path.join(upload_dir, filename), "wb") as f:
-                f.write(await photo.read())
-            t.photo_filename = filename
+            _delete_photo(t.photo_filename)
+            t.photo_filename = _save_photo(photo, await photo.read())
         db.commit()
         _flash(request, f"Updated '{name}'.")
     return RedirectResponse("/admin/appointment-types", status_code=302)
@@ -431,41 +450,20 @@ def cancel_booking_route(
     request: Request, booking_id: int, db: Session = Depends(get_db), _=AuthDep,
     _csrf_ok: None = Depends(require_csrf),
 ):
-    from app.services.booking import cancel_booking
     booking = db.query(Booking).filter_by(id=booking_id).first()
     if not booking:
         _flash(request, "Booking not found.", "error")
         return RedirectResponse("/admin/bookings", status_code=302)
 
     settings = get_settings()
-    refresh_token = get_setting(db, "google_refresh_token", "")
-    if refresh_token and settings.google_client_id:
-        cal = None
-        try:
-            cal = CalendarService(
-                settings.google_client_id,
-                settings.google_client_secret,
-                settings.google_redirect_uri,
-            )
-        except Exception:
-            pass
-        if cal:
-            try:
-                if booking.google_event_id:
-                    cal.delete_event(refresh_token, booking.appointment_type.calendar_id, booking.google_event_id)
-            except Exception:
-                pass
-            _delete_drive_time_events(cal, refresh_token, booking.appointment_type.calendar_id, booking.drive_time_event_ids)
+    delete_booking_calendar_events(db, booking, settings)
 
-    notify_enabled = get_setting(db, "notifications_enabled", "true") == "true"
-    resend_api_key = get_setting(db, "resend_api_key", settings.resend_api_key)
-    from_email = get_setting(db, "from_email", settings.from_email)
-    if notify_enabled and resend_api_key:
-        from app.services.email import send_cancellation_notice
+    email_config = get_email_config(db, settings)
+    if email_config.can_send:
         try:
-            send_cancellation_notice(
-                api_key=resend_api_key,
-                from_email=from_email,
+            email.send_cancellation_notice(
+                api_key=email_config.api_key,
+                from_email=email_config.from_email,
                 guest_email=booking.guest_email,
                 guest_name=booking.guest_name,
                 appt_type_name=booking.appointment_type.name,
@@ -473,7 +471,7 @@ def cancel_booking_route(
                 template=get_setting(db, "email_guest_cancellation", ""),
             )
         except Exception:
-            pass
+            logger.warning("Admin cancel: cancellation email failed", exc_info=True)
 
     cancel_booking(db, booking_id)
     _flash(request, f"Booking for {booking.guest_name} cancelled.")
@@ -495,7 +493,7 @@ def admin_reschedule_slots(
         target_date = date_type.fromisoformat(date)
     except ValueError:
         return HTMLResponse("")
-    slot_data = _compute_slots_for_type(
+    slot_data = compute_slots_for_type(
         booking.appointment_type, target_date, db,
         destination=booking.location, skip_advance_notice=True,
     )
@@ -515,15 +513,12 @@ def admin_reschedule_page(
         return RedirectResponse("/admin/bookings", status_code=302)
     max_future = int(get_setting(db, "max_future_days", "30"))
     now = datetime.utcnow()
-    min_date = now.date().isoformat()
-    max_date = (now + timedelta(days=max_future)).date().isoformat()
-    current_display = booking.start_datetime.strftime("%A, %B %-d, %Y at %-I:%M %p")
     return templates.TemplateResponse("admin/admin_reschedule.html", {
         "request": request,
         "booking": booking,
-        "min_date": min_date,
-        "max_date": max_date,
-        "current_display": current_display,
+        "min_date": now.date().isoformat(),
+        "max_date": (now + timedelta(days=max_future)).date().isoformat(),
+        "current_display": booking.start_datetime.strftime("%A, %B %-d, %Y at %-I:%M %p"),
         "flash": _get_flash(request),
     })
 
@@ -534,7 +529,6 @@ def admin_reschedule_booking(
     _csrf_ok: None = Depends(require_csrf),
     start_datetime: str = Form(...),
 ):
-    from app.routers.booking import _perform_reschedule
     booking = db.query(Booking).filter_by(id=booking_id, status="confirmed").first()
     if not booking:
         _flash(request, "Booking not found.", "error")
@@ -547,7 +541,7 @@ def admin_reschedule_booking(
     settings = get_settings()
     base_url = str(request.base_url).rstrip('/')
     try:
-        _perform_reschedule(db, booking, new_start_dt, settings, base_url)
+        perform_reschedule(db, booking, new_start_dt, settings, base_url)
         _flash(request, f"Booking for {booking.guest_name} rescheduled to {new_start_dt.strftime('%b %-d at %-I:%M %p')}.")
     except ValueError as exc:
         _flash(request, f"Reschedule failed: {exc}", "error")
@@ -558,19 +552,8 @@ def admin_reschedule_booking(
 
 @router.get("/settings", response_class=HTMLResponse)
 def settings_page(request: Request, db: Session = Depends(get_db), _=AuthDep):
-    import json as _json
     settings = get_settings()
     refresh_token = get_setting(db, "google_refresh_token", "")
-    cal = CalendarService(
-        settings.google_client_id,
-        settings.google_client_secret,
-        settings.google_redirect_uri,
-    )
-    conflict_cals_raw = get_setting(db, "conflict_calendars", "[]")
-    try:
-        conflict_cals = _json.loads(conflict_cals_raw)
-    except (ValueError, TypeError):
-        conflict_cals = []
     return templates.TemplateResponse("admin/settings.html", {
         "request": request,
         "owner_name": get_setting(db, "owner_name", ""),
@@ -581,8 +564,8 @@ def settings_page(request: Request, db: Session = Depends(get_db), _=AuthDep):
         "resend_api_key_set": bool(get_setting(db, "resend_api_key", settings.resend_api_key)),
         "from_email": get_setting(db, "from_email", settings.from_email),
         "contact_phone": get_setting(db, "contact_phone", ""),
-        "google_authorized": cal.is_authorized(refresh_token),
-        "conflict_cals": conflict_cals,
+        "google_authorized": bool(refresh_token),
+        "conflict_cals": get_conflict_calendars(db),
         "email_guest_confirmation": get_setting(db, "email_guest_confirmation", ""),
         "email_admin_alert": get_setting(db, "email_admin_alert", ""),
         "email_guest_cancellation": get_setting(db, "email_guest_cancellation", ""),
@@ -619,7 +602,6 @@ def save_settings(
     return RedirectResponse("/admin/settings", status_code=302)
 
 
-
 @router.post("/settings/conflict-calendars")
 def add_conflict_calendar(
     request: Request,
@@ -630,16 +612,11 @@ def add_conflict_calendar(
     _=AuthDep,
     _csrf_ok: None = Depends(require_csrf),
 ):
-    import json as _json
-    raw = get_setting(db, "conflict_calendars", "[]")
-    try:
-        cals = _json.loads(raw)
-    except (ValueError, TypeError):
-        cals = []
+    cals = get_conflict_calendars(db)
     cal_id = cal_id.strip()
     if cal_id:
         cals.append({"type": cal_type, "id": cal_id, "name": cal_name.strip() or cal_id})
-        set_setting(db, "conflict_calendars", _json.dumps(cals))
+        set_conflict_calendars(db, cals)
         _flash(request, "Conflict calendar added.")
     return RedirectResponse("/admin/settings", status_code=302)
 
@@ -649,15 +626,10 @@ def delete_conflict_calendar(
     request: Request, index: int, db: Session = Depends(get_db), _=AuthDep,
     _csrf_ok: None = Depends(require_csrf),
 ):
-    import json as _json
-    raw = get_setting(db, "conflict_calendars", "[]")
-    try:
-        cals = _json.loads(raw)
-    except (ValueError, TypeError):
-        cals = []
+    cals = get_conflict_calendars(db)
     if 0 <= index < len(cals):
         cals.pop(index)
-        set_setting(db, "conflict_calendars", _json.dumps(cals))
+        set_conflict_calendars(db, cals)
         _flash(request, "Conflict calendar removed.")
     return RedirectResponse("/admin/settings", status_code=302)
 
@@ -683,12 +655,7 @@ def save_email_templates(
 
 @router.get("/google/authorize")
 def google_authorize(request: Request, _=AuthDep):
-    settings = get_settings()
-    cal = CalendarService(
-        settings.google_client_id,
-        settings.google_client_secret,
-        settings.google_redirect_uri,
-    )
+    cal = build_calendar_service(get_settings())
     url, state, code_verifier = cal.get_auth_url()
     request.session["oauth_state"] = state
     request.session["oauth_code_verifier"] = code_verifier
@@ -705,17 +672,13 @@ def google_callback(
     if not expected_state or received_state != expected_state:
         _flash(request, "OAuth state mismatch — possible CSRF. Please try again.", "error")
         return RedirectResponse("/admin/settings", status_code=302)
-    settings = get_settings()
-    cal = CalendarService(
-        settings.google_client_id,
-        settings.google_client_secret,
-        settings.google_redirect_uri,
-    )
+    cal = build_calendar_service(get_settings())
     try:
         refresh_token = cal.exchange_code(code, code_verifier=code_verifier)
         set_setting(db, "google_refresh_token", refresh_token)
         _flash(request, "Google Calendar connected successfully.")
     except Exception as e:
+        logger.warning("Google OAuth code exchange failed", exc_info=True)
         _flash(request, f"Google Calendar connection failed: {e}", "error")
     return RedirectResponse("/admin/settings", status_code=302)
 
@@ -724,7 +687,6 @@ def google_callback(
 
 @router.get("/schedule-inspection", response_class=HTMLResponse)
 def schedule_inspection_page(request: Request, db: Session = Depends(get_db), _=AuthDep):
-    from datetime import date as _date
     admin_types = (
         db.query(AppointmentType)
         .filter_by(active=True, admin_initiated=True)
@@ -734,7 +696,7 @@ def schedule_inspection_page(request: Request, db: Session = Depends(get_db), _=
     return templates.TemplateResponse("admin/schedule_inspection.html", {
         "request": request,
         "admin_types": admin_types,
-        "today": _date.today().isoformat(),
+        "today": date_type.today().isoformat(),
         "flash": _get_flash(request),
     })
 
@@ -748,21 +710,6 @@ def inspection_slots(
     db: Session = Depends(get_db),
     _=AuthDep,
 ):
-    import json as _json
-    from datetime import date as date_type, time as time_type, timedelta, timezone as dt_timezone
-    from zoneinfo import ZoneInfo
-    from app.models import AvailabilityRule, BlockedPeriod
-    from app.services.availability import (
-        _build_free_windows,
-        intersect_windows,
-        split_into_slots,
-        filter_by_advance_notice,
-        trim_windows_for_drive_time,
-    )
-    from app.services.calendar import CalendarService
-    from app.config import get_settings
-
-    settings = get_settings()
     appt_type = db.query(AppointmentType).filter_by(id=type_id, active=True, admin_initiated=True).first()
     if not appt_type:
         return HTMLResponse("<p class='no-slots'>Appointment type not found.</p>")
@@ -771,67 +718,7 @@ def inspection_slots(
     except ValueError:
         return HTMLResponse("<p class='no-slots'>Invalid date.</p>")
 
-    tz = ZoneInfo(get_setting(db, "timezone", "America/New_York"))
-    local_midnight = datetime.combine(target_date, time_type(0, 0)).replace(tzinfo=tz)
-    day_start = local_midnight.astimezone(dt_timezone.utc).replace(tzinfo=None)
-    day_end = (local_midnight + timedelta(days=1)).astimezone(dt_timezone.utc).replace(tzinfo=None)
-
-    busy_intervals = []
-    local_day_events = []
-
-    refresh_token = get_setting(db, "google_refresh_token", "")
-    if refresh_token and settings.google_client_id:
-        cal = CalendarService(
-            settings.google_client_id,
-            settings.google_client_secret,
-            settings.google_redirect_uri,
-        )
-        try:
-            utc_busy = cal.get_busy_intervals(
-                refresh_token, [appt_type.calendar_id], day_start, day_end
-            )
-            for utc_start, utc_end in utc_busy:
-                local_start = utc_start.replace(tzinfo=dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-                local_end = utc_end.replace(tzinfo=dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-                busy_intervals.append((local_start, local_end))
-        except Exception:
-            pass
-
-        if destination:
-            try:
-                day_events_utc = cal.get_events_for_day(refresh_token, "primary", day_start, day_end)
-                for ev in day_events_utc:
-                    local_start = ev["start"].replace(tzinfo=dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-                    local_end = ev["end"].replace(tzinfo=dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-                    local_day_events.append({**ev, "start": local_start, "end": local_end})
-            except Exception:
-                pass
-
-    rules = db.query(AvailabilityRule).filter_by(active=True).all()
-    blocked = db.query(BlockedPeriod).all()
-    windows = _build_free_windows(target_date, rules, blocked, busy_intervals, appointment_type_id=appt_type.id)
-
-    if destination and windows:
-        home_address = get_setting(db, "home_address", "")
-        windows = trim_windows_for_drive_time(
-            windows, target_date, local_day_events,
-            destination=destination,
-            home_address=home_address,
-            db=db,
-        )
-
-    min_advance = int(get_setting(db, "min_advance_hours", "24"))
-    now_local = datetime.now(dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-    slots = split_into_slots(
-        windows, appt_type.duration_minutes,
-        appt_type.buffer_before_minutes, appt_type.buffer_after_minutes,
-    )
-    slots = filter_by_advance_notice(slots, target_date, min_advance, now_local)
-
-    slot_data = [
-        {"value": s.strftime("%H:%M"), "display": s.strftime("%-I:%M %p")}
-        for s in slots
-    ]
+    slot_data = compute_inspection_slots(appt_type, target_date, db, destination=destination)
     return templates.TemplateResponse("admin/inspection_slots_partial.html", {
         "request": request,
         "slots": slot_data,
@@ -848,12 +735,6 @@ async def submit_inspection(
     _=AuthDep,
     _csrf_ok: None = Depends(require_csrf),
 ):
-    from datetime import timedelta, timezone as dt_timezone
-    from zoneinfo import ZoneInfo
-    from app.services.booking import create_booking
-    from app.services.calendar import CalendarService
-    from app.routers.booking import _create_drive_time_blocks
-
     form = await request.form()
     type_id_str = str(form.get("type_id", ""))
     destination = str(form.get("destination", "")).strip()
@@ -897,14 +778,10 @@ async def submit_inspection(
     settings = get_settings()
     refresh_token = get_setting(db, "google_refresh_token", "")
     if refresh_token and settings.google_client_id:
-        cal = CalendarService(
-            settings.google_client_id,
-            settings.google_client_secret,
-            settings.google_redirect_uri,
-        )
-        tz = ZoneInfo(get_setting(db, "timezone", "America/New_York"))
-        start_utc = start_dt.replace(tzinfo=tz).astimezone(dt_timezone.utc).replace(tzinfo=None)
-        end_utc = end_dt.replace(tzinfo=tz).astimezone(dt_timezone.utc).replace(tzinfo=None)
+        cal = build_calendar_service(settings)
+        tz = get_timezone(db)
+        start_utc = local_to_utc(start_dt, tz)
+        end_utc = local_to_utc(end_dt, tz)
 
         description_lines = [f"Inspection at: {destination}"]
         if guest_name:
@@ -932,10 +809,9 @@ async def submit_inspection(
             booking.google_event_id = event_id
             db.commit()
         except Exception:
-            pass
+            logger.warning("Inspection booking %s: calendar event creation failed", booking.id, exc_info=True)
 
-        home_address = get_setting(db, "home_address", "")
-        _create_drive_time_blocks(
+        create_drive_time_blocks(
             cal=cal,
             refresh_token=refresh_token,
             calendar_id=appt_type.calendar_id,
@@ -943,7 +819,7 @@ async def submit_inspection(
             appt_location=destination,
             start_utc=start_utc,
             end_utc=end_utc,
-            home_address=home_address,
+            home_address=get_setting(db, "home_address", ""),
             db=db,
         )
 

--- a/app/routers/booking.py
+++ b/app/routers/booking.py
@@ -1,222 +1,55 @@
+import logging
 import os
-from datetime import datetime, date as date_type, timedelta, timezone as dt_timezone
-from zoneinfo import ZoneInfo
+from datetime import datetime, date as date_type, timedelta
+
 from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
+from fastapi.responses import FileResponse, HTMLResponse
 from sqlalchemy.orm import Session
 
 from app.config import get_settings
 from app.database import get_db
-from app.dependencies import get_setting, require_csrf
+from app.dependencies import get_email_config, get_setting, require_csrf
 from app.limiter import limiter
 from app.models import AppointmentType, Booking
-from app.routers.slots import _compute_slots_for_type
+from app.services import email
 from app.services.booking import create_booking
-from app.services.drive_time import get_drive_time
+from app.services.calendar import build_calendar_service
+from app.services.scheduling import (
+    create_drive_time_blocks,
+    delete_booking_calendar_events,
+    perform_reschedule,
+)
+from app.services.slots import compute_slots_for_type
+from app.services.timeutils import get_timezone, local_to_utc, now_local
+from app.templating import templates
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
-templates = Jinja2Templates(directory="app/templates")
-from app.dependencies import get_csrf_token as _get_csrf_token
-templates.env.globals["csrf_token"] = _get_csrf_token
+
+RESCHEDULE_TOKEN_ERROR = (
+    "This link has already been used or the appointment was cancelled. "
+    "If you need to book a new appointment, use the link below."
+)
+CANCEL_TOKEN_ERROR = (
+    "This appointment has already been cancelled or this link has expired. "
+    "If you need to make changes to a current booking, please contact us."
+)
 
 
-def _create_drive_time_blocks(
-    cal,
-    refresh_token: str,
-    calendar_id: str,
-    appt_name: str,
-    appt_location: str,
-    start_utc,
-    end_utc,
-    home_address: str,
-    db,
-) -> list[str]:
-    """Create BLOCK calendar events for drive time before and after the appointment.
-
-    Returns a list of created calendar event IDs (0-2 items).
-    All datetimes must be naive UTC. Failures are fully silent — this is a
-    best-effort calendar annotation, never blocking the booking confirmation.
-    """
-    created_ids: list[str] = []
-    window_start = start_utc - timedelta(hours=1)
-    window_end = end_utc + timedelta(hours=1)
-
-    try:
-        nearby_events = cal.get_events_for_day(refresh_token, calendar_id, window_start, window_end)
-    except Exception:
-        return created_ids
-
-    # --- Before block: drive TO this appointment ---
-    preceding = None
-    for ev in nearby_events:
-        if window_start <= ev["end"] <= start_utc:
-            if preceding is None or ev["end"] > preceding["end"]:
-                preceding = ev
-
-    origin = (preceding.get("location") or "").strip() if preceding else ""
-    if not origin:
-        origin = home_address
-
-    if origin and origin.lower() != appt_location.lower():
-        drive_mins = get_drive_time(origin, appt_location, db)
-        if drive_mins > 0:
-            try:
-                event_id = cal.create_event(
-                    refresh_token=refresh_token,
-                    calendar_id=calendar_id,
-                    summary=f"BLOCK - Drive Time for {appt_name}",
-                    description="",
-                    start=start_utc - timedelta(minutes=drive_mins),
-                    end=start_utc,
-                    show_as="busy",
-                    disable_reminders=True,
-                )
-                if event_id:
-                    created_ids.append(event_id)
-            except Exception:
-                pass
-
-    # --- After block: drive FROM this appointment to the next one ---
-    following = None
-    for ev in nearby_events:
-        if end_utc <= ev["start"] <= window_end:
-            if following is None or ev["start"] < following["start"]:
-                following = ev
-
-    if following:
-        dest = (following.get("location") or "").strip()
-        if dest and dest.lower() != appt_location.lower():
-            drive_mins = get_drive_time(appt_location, dest, db)
-            if drive_mins > 0:
-                try:
-                    event_id = cal.create_event(
-                        refresh_token=refresh_token,
-                        calendar_id=calendar_id,
-                        summary=f"BLOCK - Drive Time for {following['summary']}",
-                        description="",
-                        start=end_utc,
-                        end=end_utc + timedelta(minutes=drive_mins),
-                        show_as="busy",
-                        disable_reminders=True,
-                    )
-                    if event_id:
-                        created_ids.append(event_id)
-                except Exception:
-                    pass
-
-    return created_ids
+def _booking_by_token(db: Session, token: str) -> Booking | None:
+    return db.query(Booking).filter_by(reschedule_token=token, status="confirmed").first()
 
 
-def _delete_drive_time_events(cal, refresh_token: str, calendar_id: str, event_ids: list[str]) -> None:
-    """Delete stored drive time BLOCK calendar events. All failures are non-fatal."""
-    for event_id in event_ids:
-        try:
-            cal.delete_event(refresh_token, calendar_id, event_id)
-        except Exception:
-            pass
+def _token_error(request: Request, message: str):
+    return templates.TemplateResponse("booking/token_error.html", {
+        "request": request,
+        "message": message,
+    })
 
 
-def _perform_reschedule(
-    db: Session,
-    booking: Booking,
-    new_start_dt: datetime,
-    settings,
-    base_url: str,
-) -> None:
-    """Reschedule a booking to a new start time.
-
-    Operation order (guards booking integrity):
-    1. Create new calendar event — raises ValueError on failure (booking unchanged).
-    2. Delete old calendar event — non-fatal (new event already exists).
-    3. Update booking record in DB.
-    4. Send new confirmation email — non-fatal.
-    base_url: scheme + host with no trailing slash, e.g. "https://booking.devonwatkins.com"
-    """
-    from app.services.calendar import CalendarService
-
-    appt_type = booking.appointment_type
-    new_end_dt = new_start_dt + timedelta(minutes=appt_type.duration_minutes)
-
-    tz = ZoneInfo(get_setting(db, "timezone", "America/New_York"))
-    start_utc = new_start_dt.replace(tzinfo=tz).astimezone(dt_timezone.utc).replace(tzinfo=None)
-    end_utc = new_end_dt.replace(tzinfo=tz).astimezone(dt_timezone.utc).replace(tzinfo=None)
-
-    refresh_token = get_setting(db, "google_refresh_token", "")
-    old_event_id = booking.google_event_id
-    new_event_id = old_event_id  # preserve original if calendar branch is skipped
-
-    if refresh_token and settings.google_client_id:
-        cal = CalendarService(
-            settings.google_client_id,
-            settings.google_client_secret,
-            settings.google_redirect_uri,
-        )
-        description_lines = [
-            f"Guest: {booking.guest_name}",
-            f"Email: {booking.guest_email}",
-            f"Phone: {booking.guest_phone or 'not provided'}",
-            f"Notes: {booking.notes or 'none'}",
-            "(Rescheduled)",
-        ]
-        try:
-            new_event_id = cal.create_event(
-                refresh_token=refresh_token,
-                calendar_id=appt_type.calendar_id,
-                summary=appt_type.owner_event_title or f"{appt_type.name} — {booking.guest_name}",
-                description="\n".join(description_lines),
-                start=start_utc,
-                end=end_utc,
-                attendee_email="",
-                location=appt_type.location if not appt_type.admin_initiated else booking.location,
-                show_as=appt_type.show_as,
-                visibility=appt_type.visibility,
-                disable_reminders=not appt_type.owner_reminders_enabled,
-            )
-        except Exception as exc:
-            raise ValueError(f"Could not create a new calendar event: {exc}") from exc
-
-        # Delete old event after new one is confirmed (non-fatal)
-        if old_event_id:
-            try:
-                cal.delete_event(refresh_token, appt_type.calendar_id, old_event_id)
-            except Exception:
-                pass
-
-    # Update booking
-    booking.start_datetime = new_start_dt
-    booking.end_datetime = new_end_dt
-    booking.google_event_id = new_event_id
-    db.commit()
-
-    # Send new confirmation email (non-fatal; only if guest email present)
-    if booking.guest_email:
-        notify_enabled = get_setting(db, "notifications_enabled", "true") == "true"
-        resend_api_key = get_setting(db, "resend_api_key", settings.resend_api_key)
-        from_email = get_setting(db, "from_email", settings.from_email)
-        if notify_enabled and resend_api_key:
-            from app.services.email import send_guest_confirmation
-            reschedule_url = base_url + f"/reschedule/{booking.reschedule_token}"
-            cancel_url = base_url + f"/cancel/{booking.reschedule_token}"
-            try:
-                send_guest_confirmation(
-                    api_key=resend_api_key,
-                    from_email=from_email,
-                    guest_email=booking.guest_email,
-                    guest_name=booking.guest_name,
-                    appt_type_name=appt_type.guest_event_title or appt_type.name,
-                    start_dt=new_start_dt,
-                    end_dt=new_end_dt,
-                    custom_responses=booking.custom_field_responses,
-                    owner_name=get_setting(db, "owner_name", ""),
-                    template=get_setting(db, "email_guest_confirmation", ""),
-                    reschedule_url=reschedule_url,
-                    cancel_url=cancel_url,
-                    location=appt_type.location or "",
-                    contact_phone=get_setting(db, "contact_phone", ""),
-                )
-            except Exception:
-                pass
+def _format_booking_start(booking: Booking) -> str:
+    return booking.start_datetime.strftime("%A, %B %-d, %Y at %-I:%M %p")
 
 
 @router.get("/reschedule/{token}/slots", response_class=HTMLResponse)
@@ -226,7 +59,7 @@ def reschedule_slots(
     date: str,
     db: Session = Depends(get_db),
 ):
-    booking = db.query(Booking).filter_by(reschedule_token=token, status="confirmed").first()
+    booking = _booking_by_token(db, token)
     if not booking:
         raise HTTPException(status_code=404, detail="Booking not found.")
     if not date:
@@ -236,7 +69,7 @@ def reschedule_slots(
     except ValueError:
         return HTMLResponse("")
 
-    slot_data = _compute_slots_for_type(
+    slot_data = compute_slots_for_type(
         booking.appointment_type,
         target_date,
         db,
@@ -254,33 +87,24 @@ def reschedule_page(
     token: str,
     db: Session = Depends(get_db),
 ):
-    booking = db.query(Booking).filter_by(reschedule_token=token, status="confirmed").first()
+    booking = _booking_by_token(db, token)
     if not booking:
-        return templates.TemplateResponse("booking/token_error.html", {
-            "request": request,
-            "message": "This link has already been used or the appointment was cancelled. If you need to book a new appointment, use the link below.",
-        })
+        return _token_error(request, RESCHEDULE_TOKEN_ERROR)
 
     min_advance = int(get_setting(db, "min_advance_hours", "24"))
     max_future = int(get_setting(db, "max_future_days", "30"))
-    tz = ZoneInfo(get_setting(db, "timezone", "America/New_York"))
-    now_local = datetime.now(dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-    cutoff = now_local + timedelta(hours=min_advance)
-    too_close = booking.start_datetime <= cutoff
-
-    min_date = cutoff.date().isoformat()
-    max_date = (now_local + timedelta(days=max_future)).date().isoformat()
-    current_display = booking.start_datetime.strftime("%A, %B %-d, %Y at %-I:%M %p")
+    now = now_local(get_timezone(db))
+    cutoff = now + timedelta(hours=min_advance)
 
     return templates.TemplateResponse("booking/reschedule.html", {
         "request": request,
         "booking": booking,
         "token": token,
-        "too_close": too_close,
+        "too_close": booking.start_datetime <= cutoff,
         "min_advance_hours": min_advance,
-        "min_date": min_date,
-        "max_date": max_date,
-        "current_display": current_display,
+        "min_date": cutoff.date().isoformat(),
+        "max_date": (now + timedelta(days=max_future)).date().isoformat(),
+        "current_display": _format_booking_start(booking),
     })
 
 
@@ -295,57 +119,48 @@ async def submit_reschedule(
     form_data = await request.form()
     start_datetime_str = str(form_data.get("start_datetime", "")).strip()
 
-    booking = db.query(Booking).filter_by(reschedule_token=token, status="confirmed").first()
+    booking = _booking_by_token(db, token)
     if not booking:
-        return templates.TemplateResponse("booking/token_error.html", {
-            "request": request,
-            "message": "This link has already been used or the appointment was cancelled. If you need to book a new appointment, use the link below.",
-        })
+        return _token_error(request, RESCHEDULE_TOKEN_ERROR)
+
+    def _reschedule_form(**overrides):
+        context = {
+            "request": request, "booking": booking, "token": token,
+            "too_close": False, "min_advance_hours": 24,
+            "min_date": "", "max_date": "",
+            "current_display": _format_booking_start(booking),
+        }
+        context.update(overrides)
+        return templates.TemplateResponse("booking/reschedule.html", context)
 
     try:
         new_start_dt = datetime.fromisoformat(start_datetime_str)
     except (ValueError, TypeError):
-        return templates.TemplateResponse("booking/reschedule.html", {
-            "request": request, "booking": booking, "token": token,
-            "too_close": False, "min_advance_hours": 24,
-            "min_date": "", "max_date": "",
-            "current_display": booking.start_datetime.strftime("%A, %B %-d, %Y at %-I:%M %p"),
-            "error": "Invalid date/time. Please try again.",
-        })
+        return _reschedule_form(error="Invalid date/time. Please try again.")
 
     min_advance = int(get_setting(db, "min_advance_hours", "24"))
     max_future = int(get_setting(db, "max_future_days", "30"))
-    tz = ZoneInfo(get_setting(db, "timezone", "America/New_York"))
-    now_local = datetime.now(dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-    cutoff = now_local + timedelta(hours=min_advance)
+    now = now_local(get_timezone(db))
+    cutoff = now + timedelta(hours=min_advance)
+    window_context = {
+        "min_advance_hours": min_advance,
+        "min_date": cutoff.date().isoformat(),
+        "max_date": (now + timedelta(days=max_future)).date().isoformat(),
+    }
     if new_start_dt <= cutoff:
-        return templates.TemplateResponse("booking/reschedule.html", {
-            "request": request, "booking": booking, "token": token,
-            "too_close": True, "min_advance_hours": min_advance,
-            "min_date": cutoff.date().isoformat(),
-            "max_date": (now_local + timedelta(days=max_future)).date().isoformat(),
-            "current_display": booking.start_datetime.strftime("%A, %B %-d, %Y at %-I:%M %p"),
-        })
+        return _reschedule_form(too_close=True, **window_context)
 
     settings = get_settings()
     base_url = str(request.base_url).rstrip('/')
     try:
-        _perform_reschedule(db, booking, new_start_dt, settings, base_url)
+        perform_reschedule(db, booking, new_start_dt, settings, base_url)
     except ValueError as exc:
-        return templates.TemplateResponse("booking/reschedule.html", {
-            "request": request, "booking": booking, "token": token,
-            "too_close": False, "min_advance_hours": min_advance,
-            "min_date": cutoff.date().isoformat(),
-            "max_date": (now_local + timedelta(days=max_future)).date().isoformat(),
-            "current_display": booking.start_datetime.strftime("%A, %B %-d, %Y at %-I:%M %p"),
-            "error": str(exc),
-        })
+        return _reschedule_form(error=str(exc), **window_context)
 
-    new_display = new_start_dt.strftime("%A, %B %-d, %Y at %-I:%M %p")
     return templates.TemplateResponse("booking/reschedule_success.html", {
         "request": request,
         "booking": booking,
-        "new_display": new_display,
+        "new_display": new_start_dt.strftime("%A, %B %-d, %Y at %-I:%M %p"),
     })
 
 
@@ -355,18 +170,14 @@ def cancel_page(
     token: str,
     db: Session = Depends(get_db),
 ):
-    booking = db.query(Booking).filter_by(reschedule_token=token, status="confirmed").first()
+    booking = _booking_by_token(db, token)
     if not booking:
-        return templates.TemplateResponse("booking/token_error.html", {
-            "request": request,
-            "message": "This appointment has already been cancelled or this link has expired. If you need to make changes to a current booking, please contact us.",
-        })
-    current_display = booking.start_datetime.strftime("%A, %B %-d, %Y at %-I:%M %p")
+        return _token_error(request, CANCEL_TOKEN_ERROR)
     return templates.TemplateResponse("booking/cancel_confirm.html", {
         "request": request,
         "booking": booking,
         "token": token,
-        "current_display": current_display,
+        "current_display": _format_booking_start(booking),
     })
 
 
@@ -378,47 +189,22 @@ async def submit_cancel(
     db: Session = Depends(get_db),
     _csrf_ok: None = Depends(require_csrf),
 ):
-    booking = db.query(Booking).filter_by(reschedule_token=token, status="confirmed").first()
+    booking = _booking_by_token(db, token)
     if not booking:
-        return templates.TemplateResponse("booking/token_error.html", {
-            "request": request,
-            "message": "This appointment has already been cancelled or this link has expired. If you need to make changes to a current booking, please contact us.",
-        })
+        return _token_error(request, CANCEL_TOKEN_ERROR)
 
     appt_type = booking.appointment_type
     settings = get_settings()
 
-    # Delete Google Calendar event (non-fatal)
-    refresh_token = get_setting(db, "google_refresh_token", "")
-    if refresh_token and settings.google_client_id:
-        cal = None
-        try:
-            from app.services.calendar import CalendarService
-            cal = CalendarService(
-                settings.google_client_id,
-                settings.google_client_secret,
-                settings.google_redirect_uri,
-            )
-        except Exception:
-            pass
-        if cal:
-            try:
-                if booking.google_event_id:
-                    cal.delete_event(refresh_token, appt_type.calendar_id, booking.google_event_id)
-            except Exception:
-                pass
-            _delete_drive_time_events(cal, refresh_token, appt_type.calendar_id, booking.drive_time_event_ids)
+    delete_booking_calendar_events(db, booking, settings)
 
     # Send cancellation email (non-fatal)
-    notify_enabled = get_setting(db, "notifications_enabled", "true") == "true"
-    resend_api_key = get_setting(db, "resend_api_key", settings.resend_api_key)
-    from_email = get_setting(db, "from_email", settings.from_email)
-    if notify_enabled and resend_api_key and booking.guest_email:
+    email_config = get_email_config(db, settings)
+    if email_config.can_send and booking.guest_email:
         try:
-            from app.services.email import send_cancellation_notice
-            send_cancellation_notice(
-                api_key=resend_api_key,
-                from_email=from_email,
+            email.send_cancellation_notice(
+                api_key=email_config.api_key,
+                from_email=email_config.from_email,
                 guest_email=booking.guest_email,
                 guest_name=booking.guest_name,
                 appt_type_name=appt_type.guest_event_title or appt_type.name,
@@ -426,7 +212,7 @@ async def submit_cancel(
                 template=get_setting(db, "email_guest_cancellation", ""),
             )
         except Exception:
-            pass
+            logger.warning("Cancel: cancellation email failed", exc_info=True)
 
     booking.status = "cancelled"
     db.commit()
@@ -516,24 +302,23 @@ async def submit_booking(
     guest_phone = str(form_data.get("guest_phone", "")).strip()
     notes = str(form_data.get("notes", "")).strip()
 
-    if not all([type_id_str, start_datetime_str, guest_name, guest_email, guest_phone]):
+    def _error(message: str):
         return templates.TemplateResponse("booking/error_partial.html", {
-            "request": request, "message": "Please fill in all required fields."
+            "request": request, "message": message
         })
+
+    if not all([type_id_str, start_datetime_str, guest_name, guest_email, guest_phone]):
+        return _error("Please fill in all required fields.")
 
     try:
         type_id = int(type_id_str)
         start_dt = datetime.fromisoformat(start_datetime_str)
     except (ValueError, TypeError):
-        return templates.TemplateResponse("booking/error_partial.html", {
-            "request": request, "message": "Invalid booking data."
-        })
+        return _error("Invalid booking data.")
 
     appt_type = db.query(AppointmentType).filter_by(id=type_id, active=True).first()
     if not appt_type:
-        return templates.TemplateResponse("booking/error_partial.html", {
-            "request": request, "message": "Appointment type not found."
-        })
+        return _error("Appointment type not found.")
 
     end_dt = start_dt + timedelta(minutes=appt_type.duration_minutes)
 
@@ -545,16 +330,13 @@ async def submit_booking(
         Booking.end_datetime > start_dt,
     ).count()
     if overlap_count >= appt_type.max_concurrent:
-        return templates.TemplateResponse("booking/error_partial.html", {
-            "request": request,
-            "message": "That time slot was just booked. Please go back and choose another.",
-        })
+        return _error("That time slot was just booked. Please go back and choose another.")
 
     # Extract custom field responses
-    custom_responses = {}
-    for field in appt_type.custom_fields:
-        key = f"custom_{field['label']}"
-        custom_responses[field["label"]] = str(form_data.get(key, ""))
+    custom_responses = {
+        field["label"]: str(form_data.get(f"custom_{field['label']}", ""))
+        for field in appt_type.custom_fields
+    }
 
     booking = create_booking(
         db=db,
@@ -572,12 +354,7 @@ async def submit_booking(
     settings = get_settings()
     refresh_token = get_setting(db, "google_refresh_token", "")
     if refresh_token and settings.google_client_id:
-        from app.services.calendar import CalendarService
-        cal = CalendarService(
-            settings.google_client_id,
-            settings.google_client_secret,
-            settings.google_redirect_uri,
-        )
+        cal = build_calendar_service(settings)
         description_lines = [
             f"Guest: {guest_name}",
             f"Email: {guest_email}",
@@ -587,9 +364,9 @@ async def submit_booking(
         for k, v in custom_responses.items():
             description_lines.append(f"{k}: {v}")
         # start_dt/end_dt are naive local datetimes; convert to naive UTC for the calendar API
-        tz = ZoneInfo(get_setting(db, "timezone", "America/New_York"))
-        start_utc = start_dt.replace(tzinfo=tz).astimezone(dt_timezone.utc).replace(tzinfo=None)
-        end_utc = end_dt.replace(tzinfo=tz).astimezone(dt_timezone.utc).replace(tzinfo=None)
+        tz = get_timezone(db)
+        start_utc = local_to_utc(start_dt, tz)
+        end_utc = local_to_utc(end_dt, tz)
         try:
             event_id = cal.create_event(
                 refresh_token=refresh_token,
@@ -607,7 +384,8 @@ async def submit_booking(
             booking.google_event_id = event_id
             db.commit()
         except Exception:
-            pass  # Booking saved; calendar failure is non-fatal
+            # Booking saved; calendar failure is non-fatal
+            logger.warning("Booking %s: calendar event creation failed", booking.id, exc_info=True)
 
         # Drive time block events (owner-only, non-fatal)
         # Skip if this is a group showing — owner is already at the location.
@@ -620,7 +398,7 @@ async def submit_booking(
         ).first() is not None
         if appt_type.requires_drive_time and appt_type.location and not is_group_showing:
             home_address = get_setting(db, "home_address", "")
-            dt_ids = _create_drive_time_blocks(
+            dt_ids = create_drive_time_blocks(
                 cal=cal,
                 refresh_token=refresh_token,
                 calendar_id=appt_type.calendar_id,
@@ -637,20 +415,15 @@ async def submit_booking(
 
     # Email notifications
     notify_email = get_setting(db, "notify_email", "")
-    notifications_enabled = get_setting(db, "notifications_enabled", "true") == "true"
     owner_name = get_setting(db, "owner_name", "")
     guest_appt_name = appt_type.guest_event_title or appt_type.name
-    resend_api_key = get_setting(db, "resend_api_key", settings.resend_api_key)
-    from_email = get_setting(db, "from_email", settings.from_email)
-    if notifications_enabled and resend_api_key:
-        from app.services.email import send_guest_confirmation, send_admin_alert
+    email_config = get_email_config(db, settings)
+    if email_config.can_send:
         base_url = str(request.base_url).rstrip('/')
-        reschedule_url = base_url + f"/reschedule/{booking.reschedule_token}"
-        cancel_url = base_url + f"/cancel/{booking.reschedule_token}"
         try:
-            send_guest_confirmation(
-                api_key=resend_api_key,
-                from_email=from_email,
+            email.send_guest_confirmation(
+                api_key=email_config.api_key,
+                from_email=email_config.from_email,
                 guest_email=guest_email,
                 guest_name=guest_name,
                 appt_type_name=guest_appt_name,
@@ -659,18 +432,18 @@ async def submit_booking(
                 custom_responses=custom_responses,
                 owner_name=owner_name,
                 template=get_setting(db, "email_guest_confirmation", ""),
-                reschedule_url=reschedule_url,
-                cancel_url=cancel_url,
+                reschedule_url=f"{base_url}/reschedule/{booking.reschedule_token}",
+                cancel_url=f"{base_url}/cancel/{booking.reschedule_token}",
                 location=appt_type.location or "",
                 contact_phone=get_setting(db, "contact_phone", ""),
             )
         except Exception:
-            pass
+            logger.warning("Booking %s: guest confirmation email failed", booking.id, exc_info=True)
         if notify_email:
             try:
-                send_admin_alert(
-                    api_key=resend_api_key,
-                    from_email=from_email,
+                email.send_admin_alert(
+                    api_key=email_config.api_key,
+                    from_email=email_config.from_email,
                     notify_email=notify_email,
                     guest_name=guest_name,
                     guest_email=guest_email,
@@ -683,12 +456,11 @@ async def submit_booking(
                     location=appt_type.location or "",
                 )
             except Exception:
-                pass
+                logger.warning("Booking %s: admin alert email failed", booking.id, exc_info=True)
 
-    start_display = start_dt.strftime("%A, %B %-d, %Y at %-I:%M %p")
     return templates.TemplateResponse("booking/confirmation_partial.html", {
         "request": request,
         "booking": booking,
-        "start_display": start_display,
+        "start_display": start_dt.strftime("%A, %B %-d, %Y at %-I:%M %p"),
         "contact_phone": get_setting(db, "contact_phone", ""),
     })

--- a/app/routers/slots.py
+++ b/app/routers/slots.py
@@ -1,200 +1,15 @@
-import json as _json
-from datetime import datetime, date as date_type, time as time_type, timedelta, timezone as dt_timezone
-from zoneinfo import ZoneInfo
+from datetime import date as date_type
+
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import HTMLResponse
-from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.dependencies import get_setting
-from app.models import AppointmentType, Booking, AvailabilityRule, BlockedPeriod
-from app.services.availability import (
-    _build_free_windows,
-    intersect_windows,
-    split_into_slots,
-    filter_by_advance_notice,
-    trim_windows_for_drive_time,
-)
-from app.services.calendar import CalendarService
-from app.config import get_settings
+from app.models import AppointmentType
+from app.services.slots import compute_slots_for_type
+from app.templating import templates
 
 router = APIRouter()
-templates = Jinja2Templates(directory="app/templates")
-
-
-def _compute_slots_for_type(
-    appt_type,
-    target_date,
-    db,
-    destination: str = "",
-    skip_advance_notice: bool = False,
-) -> list[dict]:
-    """Compute available time slots for a given appointment type and date.
-
-    Returns a list of {"value": "HH:MM", "display": "H:MM AM/PM"} dicts.
-    destination: override location (used for admin_initiated types).
-    skip_advance_notice: when True, omit the advance-notice cutoff filter (used by admin).
-    """
-    settings = get_settings()
-    effective_location = destination if appt_type.admin_initiated else appt_type.location
-
-    rules = db.query(AvailabilityRule).filter_by(active=True).all()
-    blocked = db.query(BlockedPeriod).all()
-    min_advance = int(get_setting(db, "min_advance_hours", "24"))
-    refresh_token = get_setting(db, "google_refresh_token", "")
-    tz = ZoneInfo(get_setting(db, "timezone", "America/New_York"))
-
-    local_midnight = datetime.combine(target_date, time_type(0, 0)).replace(tzinfo=tz)
-    day_start = local_midnight.astimezone(dt_timezone.utc).replace(tzinfo=None)
-    day_end = (local_midnight + timedelta(days=1)).astimezone(dt_timezone.utc).replace(tzinfo=None)
-
-    conflict_cals_raw = get_setting(db, "conflict_calendars", "[]")
-    try:
-        conflict_cals = _json.loads(conflict_cals_raw)
-    except (ValueError, TypeError):
-        conflict_cals = []
-    extra_google_ids = [c["id"] for c in conflict_cals if c.get("type") == "google" and c.get("id")]
-    webcal_urls = [c["id"] for c in conflict_cals if c.get("type") == "webcal" and c.get("id")]
-
-    busy_intervals = []
-    window_intervals = []
-    local_day_events = []
-    calendar_window_active = bool(
-        appt_type.calendar_window_enabled and (appt_type.calendar_window_title or "").strip()
-    )
-
-    google_ids_for_freebusy = set()
-    google_ids_for_freebusy.add(appt_type.calendar_id)
-    google_ids_for_freebusy.update(extra_google_ids)
-
-    if refresh_token and settings.google_client_id:
-        cal = CalendarService(
-            settings.google_client_id,
-            settings.google_client_secret,
-            settings.google_redirect_uri,
-        )
-
-        if calendar_window_active:
-            window_cal_id = appt_type.calendar_window_calendar_id or appt_type.calendar_id
-            google_ids_for_freebusy.discard(window_cal_id)
-            try:
-                window_cal_events = cal.get_events_for_day(
-                    refresh_token,
-                    window_cal_id,
-                    day_start,
-                    day_end,
-                    include_all_day=True,
-                )
-                title_lower = appt_type.calendar_window_title.lower().strip()
-                for ev in window_cal_events:
-                    local_start = ev["start"].replace(tzinfo=dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-                    local_end = ev["end"].replace(tzinfo=dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-                    if ev["summary"].lower().strip() == title_lower:
-                        window_start = time_type(0, 0) if local_start.date() < target_date else local_start.time()
-                        window_end = time_type(23, 59, 59) if local_end.date() > target_date else local_end.time()
-                        window_intervals.append((window_start, window_end))
-                    else:
-                        busy_intervals.append((local_start, local_end))
-            except Exception:
-                pass
-
-        if google_ids_for_freebusy:
-            try:
-                utc_busy = cal.get_busy_intervals(refresh_token, list(google_ids_for_freebusy), day_start, day_end)
-                for utc_start, utc_end in utc_busy:
-                    local_start = utc_start.replace(tzinfo=dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-                    local_end = utc_end.replace(tzinfo=dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-                    busy_intervals.append((local_start, local_end))
-            except Exception:
-                pass
-
-        if appt_type.requires_drive_time and effective_location:
-            try:
-                day_events_utc = cal.get_events_for_day(refresh_token, "primary", day_start, day_end)
-                for ev in day_events_utc:
-                    local_start = ev["start"].replace(tzinfo=dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-                    local_end = ev["end"].replace(tzinfo=dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-                    local_day_events.append({**ev, "start": local_start, "end": local_end})
-            except Exception:
-                pass
-
-    for webcal_url in webcal_urls:
-        try:
-            from app.services.calendar import fetch_webcal_events
-            wc_events = fetch_webcal_events(webcal_url, day_start, day_end)
-            for ev in wc_events:
-                local_start = ev["start"].replace(tzinfo=dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-                local_end = ev["end"].replace(tzinfo=dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-                busy_intervals.append((local_start, local_end))
-                if appt_type.requires_drive_time and effective_location and ev["location"]:
-                    local_day_events.append({**ev, "start": local_start, "end": local_end})
-        except Exception:
-            pass
-
-    # Group showings: query confirmed same-type bookings for post-filtering.
-    same_type_bookings: list = []
-    if appt_type.max_concurrent > 1:
-        day_local_start = datetime.combine(target_date, time_type(0, 0))
-        day_local_end = datetime.combine(target_date, time_type(23, 59, 59))
-        same_type_bookings = db.query(Booking).filter(
-            Booking.appointment_type_id == appt_type.id,
-            Booking.status == "confirmed",
-            Booking.start_datetime >= day_local_start,
-            Booking.start_datetime <= day_local_end,
-        ).all()
-
-    windows = _build_free_windows(target_date, rules, blocked, busy_intervals, appointment_type_id=appt_type.id)
-
-    if calendar_window_active:
-        windows = intersect_windows(windows, window_intervals)
-
-    if appt_type.requires_drive_time and effective_location:
-        home_address = get_setting(db, "home_address", "")
-        windows = trim_windows_for_drive_time(
-            windows, target_date, local_day_events,
-            destination=effective_location,
-            home_address=home_address,
-            db=db,
-        )
-
-    now_local = datetime.now(dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
-    slots = split_into_slots(
-        windows, appt_type.duration_minutes,
-        appt_type.buffer_before_minutes, appt_type.buffer_after_minutes,
-    )
-    if not skip_advance_notice:
-        slots = filter_by_advance_notice(slots, target_date, min_advance, now_local)
-    else:
-        slots = filter_by_advance_notice(slots, target_date, 0, now_local)
-
-    # Group showings: inject same-type booking start times back as candidates,
-    # then post-filter by concurrent count.
-    #
-    # Why inject instead of un-blocking freebusy intervals: Google Calendar's
-    # freebusy API merges adjacent events (e.g. a drive-time block ending at
-    # 1:00 PM and a booking starting at 1:00 PM become one interval 12:30-1:20).
-    # Exact-tuple removal cannot split merged intervals, so the slot stays
-    # blocked even when capacity remains. Injecting the booking start times
-    # directly bypasses this limitation — the DB is the source of truth for
-    # which same-type slots have been taken.
-    if appt_type.max_concurrent > 1 and same_type_bookings:
-        booking_times = {b.start_datetime.time() for b in same_type_bookings}
-        slots = sorted(set(slots) | booking_times)
-
-        def _overlapping_count(slot_time) -> int:
-            slot_start_dt = datetime.combine(target_date, slot_time)
-            slot_end_dt = slot_start_dt + timedelta(minutes=appt_type.duration_minutes)
-            return sum(
-                1 for b in same_type_bookings
-                if b.start_datetime < slot_end_dt and b.end_datetime > slot_start_dt
-            )
-        slots = [s for s in slots if _overlapping_count(s) < appt_type.max_concurrent]
-
-    return [
-        {"value": s.strftime("%H:%M"), "display": s.strftime("%-I:%M %p")}
-        for s in slots
-    ]
 
 
 @router.get("/slots", response_class=HTMLResponse)
@@ -213,7 +28,7 @@ def get_slots(
     except ValueError:
         return HTMLResponse("<p class='no-slots'>Invalid date format.</p>")
 
-    slot_data = _compute_slots_for_type(appt_type, target_date, db, destination=destination)
+    slot_data = compute_slots_for_type(appt_type, target_date, db, destination=destination)
     return templates.TemplateResponse(
         "booking/slots_partial.html",
         {"request": request, "slots": slot_data, "type_id": type_id, "date": date},

--- a/app/services/calendar.py
+++ b/app/services/calendar.py
@@ -13,6 +13,15 @@ SCOPES = [
 ]
 
 
+def build_calendar_service(settings) -> "CalendarService":
+    """Construct a CalendarService from app Settings (single construction point)."""
+    return CalendarService(
+        settings.google_client_id,
+        settings.google_client_secret,
+        settings.google_redirect_uri,
+    )
+
+
 class CalendarService:
     def __init__(self, client_id: str, client_secret: str, redirect_uri: str):
         self.client_id = client_id

--- a/app/services/drive_time.py
+++ b/app/services/drive_time.py
@@ -52,17 +52,20 @@ def get_drive_time(origin: str, destination: str, db) -> int:
         data = resp.json()
         element = data["rows"][0]["elements"][0]
         if element["status"] != "OK":
+            # Don't log origin/destination: they are private addresses.
             logger.warning(
-                "Distance Matrix returned status %s for %s -> %s; using %s-minute default",
-                element["status"], origin, destination, DEFAULT_DRIVE_TIME_MINUTES,
+                "Distance Matrix returned element status %s; using %s-minute default",
+                element["status"], DEFAULT_DRIVE_TIME_MINUTES,
             )
             return DEFAULT_DRIVE_TIME_MINUTES
         duration_seconds = element["duration"]["value"]
         drive_minutes = (duration_seconds + 59) // 60  # round up to nearest minute
-    except Exception:
+    except Exception as exc:
+        # No addresses and no traceback here: httpx exception messages embed
+        # the request URL, which carries the Maps API key in its query string.
         logger.warning(
-            "Distance Matrix request failed for %s -> %s; using %s-minute default",
-            origin, destination, DEFAULT_DRIVE_TIME_MINUTES, exc_info=True,
+            "Distance Matrix request failed (%s); using %s-minute default",
+            type(exc).__name__, DEFAULT_DRIVE_TIME_MINUTES,
         )
         return DEFAULT_DRIVE_TIME_MINUTES
 

--- a/app/services/drive_time.py
+++ b/app/services/drive_time.py
@@ -1,8 +1,11 @@
+import logging
 from datetime import datetime, timedelta
 
 import httpx
 
 from app.config import get_settings
+
+logger = logging.getLogger(__name__)
 
 MAPS_DISTANCE_MATRIX_URL = "https://maps.googleapis.com/maps/api/distancematrix/json"
 CACHE_TTL_DAYS = 30
@@ -49,10 +52,18 @@ def get_drive_time(origin: str, destination: str, db) -> int:
         data = resp.json()
         element = data["rows"][0]["elements"][0]
         if element["status"] != "OK":
+            logger.warning(
+                "Distance Matrix returned status %s for %s -> %s; using %s-minute default",
+                element["status"], origin, destination, DEFAULT_DRIVE_TIME_MINUTES,
+            )
             return DEFAULT_DRIVE_TIME_MINUTES
         duration_seconds = element["duration"]["value"]
         drive_minutes = (duration_seconds + 59) // 60  # round up to nearest minute
     except Exception:
+        logger.warning(
+            "Distance Matrix request failed for %s -> %s; using %s-minute default",
+            origin, destination, DEFAULT_DRIVE_TIME_MINUTES, exc_info=True,
+        )
         return DEFAULT_DRIVE_TIME_MINUTES
 
     # Upsert cache

--- a/app/services/email.py
+++ b/app/services/email.py
@@ -7,6 +7,35 @@ def _format_dt(dt: datetime) -> str:
     return dt.strftime("%A, %B %-d, %Y at %-I:%M %p")
 
 
+def _render_custom_fields(custom_responses: dict) -> str:
+    return "".join(
+        f"<p><strong>{escape(str(k))}:</strong> {escape(str(v))}</p>"
+        for k, v in custom_responses.items() if v
+    )
+
+
+def _render(template: str, default: str, **context) -> str:
+    """Render a user-editable template, falling back to the trusted default.
+
+    Admin-edited templates may reference placeholders that no longer exist
+    (or contain stray braces); the default must always render.
+    """
+    try:
+        return (template or default).format(**context)
+    except (KeyError, ValueError, IndexError):
+        return default.format(**context)
+
+
+def _send(api_key: str, from_email: str, to_email: str, subject: str, html: str) -> None:
+    resend.api_key = api_key
+    resend.Emails.send({
+        "from": from_email,
+        "to": [to_email],
+        "subject": subject,
+        "html": html,
+    })
+
+
 # These are trusted fallback templates — all placeholders must match the kwargs in each send function.
 _GUEST_CONFIRMATION_DEFAULT = """\
 <div style="font-family:sans-serif;max-width:520px;margin:0 auto;color:#1e293b;">
@@ -65,11 +94,6 @@ def send_guest_confirmation(
     location: str = "",
     contact_phone: str = "",
 ):
-    resend.api_key = api_key
-    custom_html = "".join(
-        f"<p><strong>{escape(str(k))}:</strong> {escape(str(v))}</p>"
-        for k, v in custom_responses.items() if v
-    )
     location_row = (
         f'<tr style="border-bottom:1px solid #e2e8f0;">'
         f'<td style="padding:.5rem 1rem .5rem 0;color:#64748b;white-space:nowrap;vertical-align:top;">Location</td>'
@@ -82,36 +106,24 @@ def send_guest_confirmation(
         f'This is an agent guided tour. The agent will meet you at the property '
         f'at your appointment time. Their number is <strong>{escape(contact_phone)}</strong>.</p>'
     ) if contact_phone.strip() else ""
-    try:
-        html = (template or _GUEST_CONFIRMATION_DEFAULT).format(
-            guest_name=escape(guest_name),
-            appt_type=escape(appt_type_name),
-            date_time=_format_dt(start_dt),
-            owner_name=escape(owner_name),
-            custom_fields=custom_html,
-            reschedule_url=escape(reschedule_url),
-            cancel_url=escape(cancel_url),
-            location_row=location_row,
-            agent_info=agent_info,
-        )
-    except (KeyError, ValueError, IndexError):
-        html = _GUEST_CONFIRMATION_DEFAULT.format(
-            guest_name=escape(guest_name),
-            appt_type=escape(appt_type_name),
-            date_time=_format_dt(start_dt),
-            owner_name=escape(owner_name),
-            custom_fields=custom_html,
-            reschedule_url=escape(reschedule_url),
-            cancel_url=escape(cancel_url),
-            location_row=location_row,
-            agent_info=agent_info,
-        )
-    resend.Emails.send({
-        "from": from_email,
-        "to": [guest_email],
-        "subject": f"Your {appt_type_name} is confirmed — {start_dt.strftime('%b %-d')}",
-        "html": html,
-    })
+    html = _render(
+        template,
+        _GUEST_CONFIRMATION_DEFAULT,
+        guest_name=escape(guest_name),
+        appt_type=escape(appt_type_name),
+        date_time=_format_dt(start_dt),
+        owner_name=escape(owner_name),
+        custom_fields=_render_custom_fields(custom_responses),
+        reschedule_url=escape(reschedule_url),
+        cancel_url=escape(cancel_url),
+        location_row=location_row,
+        agent_info=agent_info,
+    )
+    _send(
+        api_key, from_email, guest_email,
+        subject=f"Your {appt_type_name} is confirmed — {start_dt.strftime('%b %-d')}",
+        html=html,
+    )
 
 
 def send_admin_alert(
@@ -128,40 +140,24 @@ def send_admin_alert(
     template: str = "",
     location: str = "",
 ):
-    resend.api_key = api_key
-    custom_html = "".join(
-        f"<p><strong>{escape(str(k))}:</strong> {escape(str(v))}</p>"
-        for k, v in custom_responses.items() if v
-    )
     location_line = f"<p><strong>Location:</strong> {escape(location)}</p>\n" if location.strip() else ""
-    try:
-        html = (template or _ADMIN_ALERT_DEFAULT).format(
-            guest_name=escape(guest_name),
-            guest_email=escape(guest_email),
-            guest_phone=escape(guest_phone or "not provided"),
-            appt_type=escape(appt_type_name),
-            date_time=_format_dt(start_dt),
-            notes=escape(notes or "none"),
-            custom_fields=custom_html,
-            location_line=location_line,
-        )
-    except (KeyError, ValueError, IndexError):
-        html = _ADMIN_ALERT_DEFAULT.format(
-            guest_name=escape(guest_name),
-            guest_email=escape(guest_email),
-            guest_phone=escape(guest_phone or "not provided"),
-            appt_type=escape(appt_type_name),
-            date_time=_format_dt(start_dt),
-            notes=escape(notes or "none"),
-            custom_fields=custom_html,
-            location_line=location_line,
-        )
-    resend.Emails.send({
-        "from": from_email,
-        "to": [notify_email],
-        "subject": f"New booking: {guest_name} — {appt_type_name} on {start_dt.strftime('%b %-d')}",
-        "html": html,
-    })
+    html = _render(
+        template,
+        _ADMIN_ALERT_DEFAULT,
+        guest_name=escape(guest_name),
+        guest_email=escape(guest_email),
+        guest_phone=escape(guest_phone or "not provided"),
+        appt_type=escape(appt_type_name),
+        date_time=_format_dt(start_dt),
+        notes=escape(notes or "none"),
+        custom_fields=_render_custom_fields(custom_responses),
+        location_line=location_line,
+    )
+    _send(
+        api_key, from_email, notify_email,
+        subject=f"New booking: {guest_name} — {appt_type_name} on {start_dt.strftime('%b %-d')}",
+        html=html,
+    )
 
 
 def send_cancellation_notice(
@@ -173,22 +169,15 @@ def send_cancellation_notice(
     start_dt: datetime,
     template: str = "",
 ):
-    resend.api_key = api_key
-    try:
-        html = (template or _CANCELLATION_DEFAULT).format(
-            guest_name=escape(guest_name),
-            appt_type=escape(appt_type_name),
-            date_time=_format_dt(start_dt),
-        )
-    except (KeyError, ValueError, IndexError):
-        html = _CANCELLATION_DEFAULT.format(
-            guest_name=escape(guest_name),
-            appt_type=escape(appt_type_name),
-            date_time=_format_dt(start_dt),
-        )
-    resend.Emails.send({
-        "from": from_email,
-        "to": [guest_email],
-        "subject": f"Your {appt_type_name} on {start_dt.strftime('%b %-d')} has been cancelled",
-        "html": html,
-    })
+    html = _render(
+        template,
+        _CANCELLATION_DEFAULT,
+        guest_name=escape(guest_name),
+        appt_type=escape(appt_type_name),
+        date_time=_format_dt(start_dt),
+    )
+    _send(
+        api_key, from_email, guest_email,
+        subject=f"Your {appt_type_name} on {start_dt.strftime('%b %-d')} has been cancelled",
+        html=html,
+    )

--- a/app/services/scheduling.py
+++ b/app/services/scheduling.py
@@ -1,0 +1,222 @@
+"""Booking lifecycle operations that touch Google Calendar and email.
+
+These were previously private helpers inside app.routers.booking and were
+imported across router modules; they live here so routers stay thin HTTP
+adapters.
+"""
+import logging
+from datetime import datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_email_config, get_setting
+from app.models import Booking
+from app.services import email
+from app.services.calendar import build_calendar_service
+from app.services.drive_time import get_drive_time
+from app.services.timeutils import get_timezone, local_to_utc
+
+logger = logging.getLogger(__name__)
+
+
+def create_drive_time_blocks(
+    cal,
+    refresh_token: str,
+    calendar_id: str,
+    appt_name: str,
+    appt_location: str,
+    start_utc: datetime,
+    end_utc: datetime,
+    home_address: str,
+    db: Session,
+) -> list[str]:
+    """Create BLOCK calendar events for drive time before and after the appointment.
+
+    Returns a list of created calendar event IDs (0-2 items).
+    All datetimes must be naive UTC. Failures never propagate — this is a
+    best-effort calendar annotation, never blocking the booking confirmation.
+    """
+    created_ids: list[str] = []
+    window_start = start_utc - timedelta(hours=1)
+    window_end = end_utc + timedelta(hours=1)
+
+    try:
+        nearby_events = cal.get_events_for_day(refresh_token, calendar_id, window_start, window_end)
+    except Exception:
+        logger.warning("Drive-time block: nearby-event fetch failed", exc_info=True)
+        return created_ids
+
+    # --- Before block: drive TO this appointment ---
+    preceding = None
+    for ev in nearby_events:
+        if window_start <= ev["end"] <= start_utc:
+            if preceding is None or ev["end"] > preceding["end"]:
+                preceding = ev
+
+    origin = (preceding.get("location") or "").strip() if preceding else ""
+    if not origin:
+        origin = home_address
+
+    if origin and origin.lower() != appt_location.lower():
+        drive_mins = get_drive_time(origin, appt_location, db)
+        if drive_mins > 0:
+            try:
+                event_id = cal.create_event(
+                    refresh_token=refresh_token,
+                    calendar_id=calendar_id,
+                    summary=f"BLOCK - Drive Time for {appt_name}",
+                    description="",
+                    start=start_utc - timedelta(minutes=drive_mins),
+                    end=start_utc,
+                    show_as="busy",
+                    disable_reminders=True,
+                )
+                if event_id:
+                    created_ids.append(event_id)
+            except Exception:
+                logger.warning("Drive-time block: before-block creation failed", exc_info=True)
+
+    # --- After block: drive FROM this appointment to the next one ---
+    following = None
+    for ev in nearby_events:
+        if end_utc <= ev["start"] <= window_end:
+            if following is None or ev["start"] < following["start"]:
+                following = ev
+
+    if following:
+        dest = (following.get("location") or "").strip()
+        if dest and dest.lower() != appt_location.lower():
+            drive_mins = get_drive_time(appt_location, dest, db)
+            if drive_mins > 0:
+                try:
+                    event_id = cal.create_event(
+                        refresh_token=refresh_token,
+                        calendar_id=calendar_id,
+                        summary=f"BLOCK - Drive Time for {following['summary']}",
+                        description="",
+                        start=end_utc,
+                        end=end_utc + timedelta(minutes=drive_mins),
+                        show_as="busy",
+                        disable_reminders=True,
+                    )
+                    if event_id:
+                        created_ids.append(event_id)
+                except Exception:
+                    logger.warning("Drive-time block: after-block creation failed", exc_info=True)
+
+    return created_ids
+
+
+def delete_drive_time_events(cal, refresh_token: str, calendar_id: str, event_ids: list[str]) -> None:
+    """Delete stored drive time BLOCK calendar events. All failures are non-fatal."""
+    for event_id in event_ids:
+        try:
+            cal.delete_event(refresh_token, calendar_id, event_id)
+        except Exception:
+            logger.warning("Drive-time block: deletion of event %s failed", event_id, exc_info=True)
+
+
+def delete_booking_calendar_events(db: Session, booking: Booking, settings) -> None:
+    """Delete a booking's Google event and its drive-time blocks. Non-fatal."""
+    refresh_token = get_setting(db, "google_refresh_token", "")
+    if not (refresh_token and settings.google_client_id):
+        return
+    cal = build_calendar_service(settings)
+    calendar_id = booking.appointment_type.calendar_id
+    if booking.google_event_id:
+        try:
+            cal.delete_event(refresh_token, calendar_id, booking.google_event_id)
+        except Exception:
+            logger.warning("Cancel: deletion of event %s failed", booking.google_event_id, exc_info=True)
+    delete_drive_time_events(cal, refresh_token, calendar_id, booking.drive_time_event_ids)
+
+
+def perform_reschedule(
+    db: Session,
+    booking: Booking,
+    new_start_dt: datetime,
+    settings,
+    base_url: str,
+) -> None:
+    """Reschedule a booking to a new start time.
+
+    Operation order (guards booking integrity):
+    1. Create new calendar event — raises ValueError on failure (booking unchanged).
+    2. Delete old calendar event — non-fatal (new event already exists).
+    3. Update booking record in DB.
+    4. Send new confirmation email — non-fatal.
+    base_url: scheme + host with no trailing slash, e.g. "https://booking.devonwatkins.com"
+    """
+    appt_type = booking.appointment_type
+    new_end_dt = new_start_dt + timedelta(minutes=appt_type.duration_minutes)
+
+    tz = get_timezone(db)
+    start_utc = local_to_utc(new_start_dt, tz)
+    end_utc = local_to_utc(new_end_dt, tz)
+
+    refresh_token = get_setting(db, "google_refresh_token", "")
+    old_event_id = booking.google_event_id
+    new_event_id = old_event_id  # preserve original if calendar branch is skipped
+
+    if refresh_token and settings.google_client_id:
+        cal = build_calendar_service(settings)
+        description_lines = [
+            f"Guest: {booking.guest_name}",
+            f"Email: {booking.guest_email}",
+            f"Phone: {booking.guest_phone or 'not provided'}",
+            f"Notes: {booking.notes or 'none'}",
+            "(Rescheduled)",
+        ]
+        try:
+            new_event_id = cal.create_event(
+                refresh_token=refresh_token,
+                calendar_id=appt_type.calendar_id,
+                summary=appt_type.owner_event_title or f"{appt_type.name} — {booking.guest_name}",
+                description="\n".join(description_lines),
+                start=start_utc,
+                end=end_utc,
+                attendee_email="",
+                location=appt_type.location if not appt_type.admin_initiated else booking.location,
+                show_as=appt_type.show_as,
+                visibility=appt_type.visibility,
+                disable_reminders=not appt_type.owner_reminders_enabled,
+            )
+        except Exception as exc:
+            raise ValueError(f"Could not create a new calendar event: {exc}") from exc
+
+        # Delete old event after new one is confirmed (non-fatal)
+        if old_event_id:
+            try:
+                cal.delete_event(refresh_token, appt_type.calendar_id, old_event_id)
+            except Exception:
+                logger.warning("Reschedule: deletion of old event %s failed", old_event_id, exc_info=True)
+
+    # Update booking
+    booking.start_datetime = new_start_dt
+    booking.end_datetime = new_end_dt
+    booking.google_event_id = new_event_id
+    db.commit()
+
+    # Send new confirmation email (non-fatal; only if guest email present)
+    if booking.guest_email:
+        email_config = get_email_config(db, settings)
+        if email_config.can_send:
+            try:
+                email.send_guest_confirmation(
+                    api_key=email_config.api_key,
+                    from_email=email_config.from_email,
+                    guest_email=booking.guest_email,
+                    guest_name=booking.guest_name,
+                    appt_type_name=appt_type.guest_event_title or appt_type.name,
+                    start_dt=new_start_dt,
+                    end_dt=new_end_dt,
+                    custom_responses=booking.custom_field_responses,
+                    owner_name=get_setting(db, "owner_name", ""),
+                    template=get_setting(db, "email_guest_confirmation", ""),
+                    reschedule_url=f"{base_url}/reschedule/{booking.reschedule_token}",
+                    cancel_url=f"{base_url}/cancel/{booking.reschedule_token}",
+                    location=appt_type.location or "",
+                    contact_phone=get_setting(db, "contact_phone", ""),
+                )
+            except Exception:
+                logger.warning("Reschedule: confirmation email failed", exc_info=True)

--- a/app/services/slots.py
+++ b/app/services/slots.py
@@ -11,6 +11,7 @@ local time before interval math (see app.services.timeutils).
 """
 import logging
 from datetime import date, datetime, time as time_type, timedelta, timezone as dt_timezone
+from urllib.parse import urlparse
 
 from sqlalchemy.orm import Session
 
@@ -161,8 +162,13 @@ def compute_slots_for_type(
                 busy_intervals.append((local_ev["start"], local_ev["end"]))
                 if appt_type.requires_drive_time and effective_location and ev["location"]:
                     local_day_events.append(local_ev)
-        except Exception:
-            logger.warning("Webcal fetch failed for %s", webcal_url, exc_info=True)
+        except Exception as exc:
+            # Log host + exception class only: webcal URLs are capability
+            # secrets, and httpx exception messages embed the full URL.
+            logger.warning(
+                "Webcal fetch failed for feed host %s (%s)",
+                urlparse(webcal_url).netloc, type(exc).__name__,
+            )
 
     # Group showings: query confirmed same-type bookings for post-filtering.
     same_type_bookings: list[Booking] = []

--- a/app/services/slots.py
+++ b/app/services/slots.py
@@ -1,0 +1,265 @@
+"""Slot computation engine.
+
+Orchestrates everything needed to answer "which start times are available
+for this appointment type on this date": availability rules, blocked
+periods, Google Calendar busy intervals, webcal feeds, calendar-window
+mode, drive-time trimming, advance-notice filtering and group-showing
+capacity.
+
+All Google Calendar / webcal data is fetched in UTC and converted to naive
+local time before interval math (see app.services.timeutils).
+"""
+import logging
+from datetime import date, datetime, time as time_type, timedelta, timezone as dt_timezone
+
+from sqlalchemy.orm import Session
+
+from app.config import get_settings
+from app.dependencies import get_conflict_calendars, get_setting
+from app.models import AppointmentType, AvailabilityRule, BlockedPeriod, Booking
+from app.services.availability import (
+    _build_free_windows,
+    filter_by_advance_notice,
+    intersect_windows,
+    split_into_slots,
+    trim_windows_for_drive_time,
+)
+from app.services.calendar import build_calendar_service, fetch_webcal_events
+from app.services.timeutils import get_timezone, local_day_bounds_utc, utc_to_local
+
+logger = logging.getLogger(__name__)
+
+
+def _format_slots(slots: list[time_type]) -> list[dict]:
+    """Format start times for the slot-button partials."""
+    return [
+        {"value": s.strftime("%H:%M"), "display": s.strftime("%-I:%M %p")}
+        for s in slots
+    ]
+
+
+def _localize_event(ev: dict, tz) -> dict:
+    """Convert an event dict's naive-UTC start/end to naive local time."""
+    return {**ev, "start": utc_to_local(ev["start"], tz), "end": utc_to_local(ev["end"], tz)}
+
+
+def _apply_group_capacity(
+    slots: list[time_type],
+    same_type_bookings: list[Booking],
+    target_date: date,
+    duration_minutes: int,
+    max_concurrent: int,
+) -> list[time_type]:
+    """Group showings: re-admit booked start times, then enforce capacity.
+
+    Why inject instead of un-blocking freebusy intervals: Google Calendar's
+    freebusy API merges adjacent events (e.g. a drive-time block ending at
+    1:00 PM and a booking starting at 1:00 PM become one interval 12:30-1:20).
+    Exact-tuple removal cannot split merged intervals, so the slot stays
+    blocked even when capacity remains. Injecting the booking start times
+    directly bypasses this limitation — the DB is the source of truth for
+    which same-type slots have been taken.
+    """
+    booking_times = {b.start_datetime.time() for b in same_type_bookings}
+    candidates = sorted(set(slots) | booking_times)
+
+    def _overlapping_count(slot_time: time_type) -> int:
+        slot_start_dt = datetime.combine(target_date, slot_time)
+        slot_end_dt = slot_start_dt + timedelta(minutes=duration_minutes)
+        return sum(
+            1 for b in same_type_bookings
+            if b.start_datetime < slot_end_dt and b.end_datetime > slot_start_dt
+        )
+
+    return [s for s in candidates if _overlapping_count(s) < max_concurrent]
+
+
+def compute_slots_for_type(
+    appt_type: AppointmentType,
+    target_date: date,
+    db: Session,
+    destination: str = "",
+    skip_advance_notice: bool = False,
+) -> list[dict]:
+    """Compute available time slots for a given appointment type and date.
+
+    Returns a list of {"value": "HH:MM", "display": "H:MM AM/PM"} dicts.
+    destination: override location (used for admin_initiated types).
+    skip_advance_notice: when True, omit the advance-notice cutoff filter (used by admin).
+    """
+    settings = get_settings()
+    effective_location = destination if appt_type.admin_initiated else appt_type.location
+
+    rules = db.query(AvailabilityRule).filter_by(active=True).all()
+    blocked = db.query(BlockedPeriod).all()
+    min_advance = int(get_setting(db, "min_advance_hours", "24"))
+    refresh_token = get_setting(db, "google_refresh_token", "")
+    tz = get_timezone(db)
+    day_start, day_end = local_day_bounds_utc(target_date, tz)
+
+    conflict_cals = get_conflict_calendars(db)
+    extra_google_ids = [c["id"] for c in conflict_cals if c.get("type") == "google" and c.get("id")]
+    webcal_urls = [c["id"] for c in conflict_cals if c.get("type") == "webcal" and c.get("id")]
+
+    busy_intervals: list[tuple[datetime, datetime]] = []
+    window_intervals: list[tuple[time_type, time_type]] = []
+    local_day_events: list[dict] = []
+    calendar_window_active = bool(
+        appt_type.calendar_window_enabled and (appt_type.calendar_window_title or "").strip()
+    )
+
+    google_ids_for_freebusy = {appt_type.calendar_id, *extra_google_ids}
+
+    if refresh_token and settings.google_client_id:
+        cal = build_calendar_service(settings)
+
+        if calendar_window_active:
+            window_cal_id = appt_type.calendar_window_calendar_id or appt_type.calendar_id
+            google_ids_for_freebusy.discard(window_cal_id)
+            try:
+                window_cal_events = cal.get_events_for_day(
+                    refresh_token,
+                    window_cal_id,
+                    day_start,
+                    day_end,
+                    include_all_day=True,
+                )
+                title_lower = appt_type.calendar_window_title.lower().strip()
+                for ev in window_cal_events:
+                    local_ev = _localize_event(ev, tz)
+                    local_start, local_end = local_ev["start"], local_ev["end"]
+                    if ev["summary"].lower().strip() == title_lower:
+                        window_start = time_type(0, 0) if local_start.date() < target_date else local_start.time()
+                        window_end = time_type(23, 59, 59) if local_end.date() > target_date else local_end.time()
+                        window_intervals.append((window_start, window_end))
+                    else:
+                        busy_intervals.append((local_start, local_end))
+            except Exception:
+                logger.warning("Calendar-window event fetch failed for calendar %s", window_cal_id, exc_info=True)
+
+        if google_ids_for_freebusy:
+            try:
+                utc_busy = cal.get_busy_intervals(refresh_token, list(google_ids_for_freebusy), day_start, day_end)
+                busy_intervals.extend(
+                    (utc_to_local(utc_start, tz), utc_to_local(utc_end, tz))
+                    for utc_start, utc_end in utc_busy
+                )
+            except Exception:
+                logger.warning("Google freebusy query failed", exc_info=True)
+
+        if appt_type.requires_drive_time and effective_location:
+            try:
+                day_events_utc = cal.get_events_for_day(refresh_token, "primary", day_start, day_end)
+                local_day_events.extend(_localize_event(ev, tz) for ev in day_events_utc)
+            except Exception:
+                logger.warning("Drive-time day-event fetch failed", exc_info=True)
+
+    for webcal_url in webcal_urls:
+        try:
+            for ev in fetch_webcal_events(webcal_url, day_start, day_end):
+                local_ev = _localize_event(ev, tz)
+                busy_intervals.append((local_ev["start"], local_ev["end"]))
+                if appt_type.requires_drive_time and effective_location and ev["location"]:
+                    local_day_events.append(local_ev)
+        except Exception:
+            logger.warning("Webcal fetch failed for %s", webcal_url, exc_info=True)
+
+    # Group showings: query confirmed same-type bookings for post-filtering.
+    same_type_bookings: list[Booking] = []
+    if appt_type.max_concurrent > 1:
+        same_type_bookings = db.query(Booking).filter(
+            Booking.appointment_type_id == appt_type.id,
+            Booking.status == "confirmed",
+            Booking.start_datetime >= datetime.combine(target_date, time_type(0, 0)),
+            Booking.start_datetime <= datetime.combine(target_date, time_type(23, 59, 59)),
+        ).all()
+
+    windows = _build_free_windows(target_date, rules, blocked, busy_intervals, appointment_type_id=appt_type.id)
+
+    if calendar_window_active:
+        windows = intersect_windows(windows, window_intervals)
+
+    if appt_type.requires_drive_time and effective_location:
+        windows = trim_windows_for_drive_time(
+            windows, target_date, local_day_events,
+            destination=effective_location,
+            home_address=get_setting(db, "home_address", ""),
+            db=db,
+        )
+
+    now_local = datetime.now(dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
+    slots = split_into_slots(
+        windows, appt_type.duration_minutes,
+        appt_type.buffer_before_minutes, appt_type.buffer_after_minutes,
+    )
+    min_advance_effective = 0 if skip_advance_notice else min_advance
+    slots = filter_by_advance_notice(slots, target_date, min_advance_effective, now_local)
+
+    if appt_type.max_concurrent > 1 and same_type_bookings:
+        slots = _apply_group_capacity(
+            slots, same_type_bookings, target_date,
+            appt_type.duration_minutes, appt_type.max_concurrent,
+        )
+
+    return _format_slots(slots)
+
+
+def compute_inspection_slots(
+    appt_type: AppointmentType,
+    target_date: date,
+    db: Session,
+    destination: str = "",
+) -> list[dict]:
+    """Compute slots for the admin "schedule inspection" flow.
+
+    A deliberately narrower variant of compute_slots_for_type: it checks only
+    the appointment type's own calendar for conflicts (no conflict calendars,
+    webcal feeds, calendar-window mode, or group capacity) and trims for
+    drive time to the ad-hoc destination.
+    """
+    settings = get_settings()
+    tz = get_timezone(db)
+    day_start, day_end = local_day_bounds_utc(target_date, tz)
+
+    busy_intervals: list[tuple[datetime, datetime]] = []
+    local_day_events: list[dict] = []
+
+    refresh_token = get_setting(db, "google_refresh_token", "")
+    if refresh_token and settings.google_client_id:
+        cal = build_calendar_service(settings)
+        try:
+            utc_busy = cal.get_busy_intervals(refresh_token, [appt_type.calendar_id], day_start, day_end)
+            busy_intervals.extend(
+                (utc_to_local(utc_start, tz), utc_to_local(utc_end, tz))
+                for utc_start, utc_end in utc_busy
+            )
+        except Exception:
+            logger.warning("Google freebusy query failed", exc_info=True)
+
+        if destination:
+            try:
+                day_events_utc = cal.get_events_for_day(refresh_token, "primary", day_start, day_end)
+                local_day_events.extend(_localize_event(ev, tz) for ev in day_events_utc)
+            except Exception:
+                logger.warning("Drive-time day-event fetch failed", exc_info=True)
+
+    rules = db.query(AvailabilityRule).filter_by(active=True).all()
+    blocked = db.query(BlockedPeriod).all()
+    windows = _build_free_windows(target_date, rules, blocked, busy_intervals, appointment_type_id=appt_type.id)
+
+    if destination and windows:
+        windows = trim_windows_for_drive_time(
+            windows, target_date, local_day_events,
+            destination=destination,
+            home_address=get_setting(db, "home_address", ""),
+            db=db,
+        )
+
+    min_advance = int(get_setting(db, "min_advance_hours", "24"))
+    now_local = datetime.now(dt_timezone.utc).astimezone(tz).replace(tzinfo=None)
+    slots = split_into_slots(
+        windows, appt_type.duration_minutes,
+        appt_type.buffer_before_minutes, appt_type.buffer_after_minutes,
+    )
+    slots = filter_by_advance_notice(slots, target_date, min_advance, now_local)
+    return _format_slots(slots)

--- a/app/services/timeutils.py
+++ b/app/services/timeutils.py
@@ -1,0 +1,43 @@
+"""Timezone conversion helpers.
+
+The app stores and computes everything as *naive* datetimes in two frames:
+local wall-clock time (bookings, availability rules, slots shown to guests)
+and UTC (Google Calendar API, webcal feeds). These helpers are the single
+place where conversion between the two frames happens.
+"""
+from datetime import date, datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_setting
+
+DEFAULT_TIMEZONE = "America/New_York"
+
+
+def get_timezone(db: Session) -> ZoneInfo:
+    """Return the owner's configured timezone (Settings table, with default)."""
+    return ZoneInfo(get_setting(db, "timezone", DEFAULT_TIMEZONE))
+
+
+def utc_to_local(dt: datetime, tz: ZoneInfo) -> datetime:
+    """Convert a naive UTC datetime to a naive local datetime."""
+    return dt.replace(tzinfo=timezone.utc).astimezone(tz).replace(tzinfo=None)
+
+
+def local_to_utc(dt: datetime, tz: ZoneInfo) -> datetime:
+    """Convert a naive local datetime to a naive UTC datetime."""
+    return dt.replace(tzinfo=tz).astimezone(timezone.utc).replace(tzinfo=None)
+
+
+def now_local(tz: ZoneInfo) -> datetime:
+    """Return the current time as a naive local datetime."""
+    return datetime.now(timezone.utc).astimezone(tz).replace(tzinfo=None)
+
+
+def local_day_bounds_utc(target_date: date, tz: ZoneInfo) -> tuple[datetime, datetime]:
+    """Return (start, end) of a local calendar day as naive UTC datetimes."""
+    local_midnight = datetime.combine(target_date, time(0, 0)).replace(tzinfo=tz)
+    day_start = local_midnight.astimezone(timezone.utc).replace(tzinfo=None)
+    day_end = (local_midnight + timedelta(days=1)).astimezone(timezone.utc).replace(tzinfo=None)
+    return day_start, day_end

--- a/app/templating.py
+++ b/app/templating.py
@@ -1,0 +1,12 @@
+"""Shared Jinja2 environment for all routers.
+
+Previously each router built its own Jinja2Templates instance and registered
+globals/filters independently; this is the single configured instance.
+"""
+from fastapi.templating import Jinja2Templates
+
+from app.dependencies import get_csrf_token
+
+templates = Jinja2Templates(directory="app/templates")
+templates.env.filters["enumerate"] = enumerate
+templates.env.globals["csrf_token"] = get_csrf_token

--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -40,7 +40,7 @@ def test_logout_redirects_to_authentik_end_session(client):
 def test_google_authorize_stores_state_and_code_verifier_in_session():
     request = SimpleNamespace(session={})
     with unittest.mock.patch("app.routers.admin.get_settings") as mock_settings, \
-         unittest.mock.patch("app.routers.admin.CalendarService") as MockCalendarService:
+         unittest.mock.patch("app.routers.admin.build_calendar_service") as MockCalendarService:
         mock_settings.return_value.google_client_id = "cid"
         mock_settings.return_value.google_client_secret = "secret"
         mock_settings.return_value.google_redirect_uri = "https://example.com/callback"
@@ -63,7 +63,7 @@ def test_google_callback_passes_stored_code_verifier_to_exchange():
     )
     db = unittest.mock.MagicMock()
     with unittest.mock.patch("app.routers.admin.get_settings") as mock_settings, \
-         unittest.mock.patch("app.routers.admin.CalendarService") as MockCalendarService, \
+         unittest.mock.patch("app.routers.admin.build_calendar_service") as MockCalendarService, \
          unittest.mock.patch("app.routers.admin.set_setting") as mock_set_setting:
         mock_settings.return_value.google_client_id = "cid"
         mock_settings.return_value.google_client_secret = "secret"

--- a/tests/test_admin_inspection.py
+++ b/tests/test_admin_inspection.py
@@ -71,7 +71,7 @@ def test_schedule_inspection_creates_booking(insp_client):
     type_id = t.id
     db.close()
 
-    with patch("app.routers.admin.CalendarService"):
+    with patch("app.routers.admin.build_calendar_service"):
         resp = client.post("/admin/schedule-inspection", data={
             "type_id": str(type_id),
             "destination": "456 Oak Ave, Atlanta GA 30318",
@@ -110,7 +110,7 @@ def test_schedule_inspection_no_email_sent(insp_client):
     type_id = t.id
     db.close()
 
-    with patch("app.routers.admin.CalendarService"), \
+    with patch("app.routers.admin.build_calendar_service"), \
          patch("app.services.email.send_guest_confirmation") as mock_email:
         client.post("/admin/schedule-inspection", data={
             "type_id": str(type_id),
@@ -149,7 +149,7 @@ def test_inspection_slots_returns_html(insp_client):
     type_id = t.id
     db.close()
 
-    with patch("app.routers.admin.datetime") as mock_dt, \
+    with patch("app.services.slots.datetime") as mock_dt, \
          patch("app.services.availability.get_drive_time", return_value=0):
         mock_dt.now.return_value = datetime(2025, 3, 1, 0, 0, 0, tzinfo=dt_timezone.utc)
         mock_dt.combine = datetime.combine

--- a/tests/test_booking_route.py
+++ b/tests/test_booking_route.py
@@ -190,18 +190,18 @@ def test_booking_model_has_drive_time_event_ids():
     assert b._drive_time_event_ids == '["abc", "def"]'
 
 
-def test_create_drive_time_blocks_returns_list():
-    """_create_drive_time_blocks should return a list (possibly empty)."""
+def testcreate_drive_time_blocks_returns_list():
+    """create_drive_time_blocks should return a list (possibly empty)."""
     from unittest.mock import MagicMock, patch
-    from app.routers.booking import _create_drive_time_blocks
+    from app.services.scheduling import create_drive_time_blocks
     import datetime
 
     cal = MagicMock()
     cal.get_events_for_day.return_value = []
     cal.create_event.return_value = "event-id-123"
 
-    with patch("app.routers.booking.get_drive_time", return_value=0):
-        result = _create_drive_time_blocks(
+    with patch("app.services.scheduling.get_drive_time", return_value=0):
+        result = create_drive_time_blocks(
             cal=cal,
             refresh_token="tok",
             calendar_id="primary",

--- a/tests/test_drive_time_blocks.py
+++ b/tests/test_drive_time_blocks.py
@@ -1,5 +1,5 @@
 # tests/test_drive_time_blocks.py
-"""Unit tests for _create_drive_time_blocks in app/routers/booking.py."""
+"""Unit tests for create_drive_time_blocks in app/services/scheduling.py."""
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch, call
 
@@ -15,8 +15,8 @@ def _make_cal():
 def _run(cal, nearby_events, drive_minutes, appt_name="Consultation",
          appt_location="456 Property Ln", home_address="123 Home St",
          start_utc=None, end_utc=None):
-    """Helper: patch get_events_for_day and get_drive_time, then call _create_drive_time_blocks."""
-    from app.routers.booking import _create_drive_time_blocks
+    """Helper: patch get_events_for_day and get_drive_time, then call create_drive_time_blocks."""
+    from app.services.scheduling import create_drive_time_blocks
 
     if start_utc is None:
         start_utc = datetime(2026, 3, 1, 15, 0)   # 3:00 PM UTC
@@ -26,8 +26,8 @@ def _run(cal, nearby_events, drive_minutes, appt_name="Consultation",
     cal.get_events_for_day.return_value = nearby_events
 
     db = MagicMock()
-    with patch("app.routers.booking.get_drive_time", return_value=drive_minutes):
-        _create_drive_time_blocks(
+    with patch("app.services.scheduling.get_drive_time", return_value=drive_minutes):
+        create_drive_time_blocks(
             cal=cal,
             refresh_token="tok",
             calendar_id="primary",
@@ -266,7 +266,7 @@ def test_after_block_uses_earliest_following_event():
 
 
 def test_submit_booking_calls_drive_time_blocks_when_requires_drive_time():
-    """submit_booking calls _create_drive_time_blocks when requires_drive_time is True."""
+    """submit_booking calls create_drive_time_blocks when requires_drive_time is True."""
     from sqlalchemy import create_engine
     from sqlalchemy.orm import sessionmaker
     from sqlalchemy.pool import StaticPool
@@ -312,7 +312,7 @@ def test_submit_booking_calls_drive_time_blocks_when_requires_drive_time():
     app.dependency_overrides[get_db] = override
     app.dependency_overrides[require_csrf] = lambda: None
 
-    with patch("app.routers.booking._create_drive_time_blocks") as mock_blocks:
+    with patch("app.routers.booking.create_drive_time_blocks") as mock_blocks:
         mock_blocks.return_value = []
         with patch("app.routers.booking.get_settings") as mock_settings:
             from app.config import Settings

--- a/tests/test_group_showings.py
+++ b/tests/test_group_showings.py
@@ -109,8 +109,8 @@ def test_group_showing_slot_appears_when_one_booking_exists():
 
     mock_cal = _mock_cal_returning_booking_as_busy()
 
-    with patch("app.routers.slots.CalendarService", return_value=mock_cal), \
-         patch("app.routers.slots.get_settings") as ms:
+    with patch("app.services.slots.build_calendar_service", return_value=mock_cal), \
+         patch("app.services.slots.get_settings") as ms:
         _patch_slots_settings(ms)
         response = client.get(f"/slots?type_id={type_id}&date={TEST_DATE}")
 
@@ -144,8 +144,8 @@ def test_group_showing_slot_blocked_at_capacity():
 
     mock_cal = _mock_cal_returning_booking_as_busy()
 
-    with patch("app.routers.slots.CalendarService", return_value=mock_cal), \
-         patch("app.routers.slots.get_settings") as ms:
+    with patch("app.services.slots.build_calendar_service", return_value=mock_cal), \
+         patch("app.services.slots.get_settings") as ms:
         _patch_slots_settings(ms)
         response = client.get(f"/slots?type_id={type_id}&date={TEST_DATE}")
 
@@ -167,8 +167,8 @@ def test_standard_type_blocks_slot_normally():
 
     mock_cal = _mock_cal_returning_booking_as_busy()
 
-    with patch("app.routers.slots.CalendarService", return_value=mock_cal), \
-         patch("app.routers.slots.get_settings") as ms:
+    with patch("app.services.slots.build_calendar_service", return_value=mock_cal), \
+         patch("app.services.slots.get_settings") as ms:
         _patch_slots_settings(ms)
         response = client.get(f"/slots?type_id={type_id}&date={TEST_DATE}")
 
@@ -179,7 +179,7 @@ def test_standard_type_blocks_slot_normally():
 
 
 def test_group_showing_skips_drive_time_blocks():
-    """A group showing booking should not trigger _create_drive_time_blocks."""
+    """A group showing booking should not trigger create_drive_time_blocks."""
     from app.limiter import limiter
     limiter._storage.reset()
 
@@ -206,7 +206,7 @@ def test_group_showing_skips_drive_time_blocks():
     mock_settings.from_email = "test@example.com"
 
     with patch("app.routers.booking.get_settings", return_value=mock_settings), \
-         patch("app.routers.booking._create_drive_time_blocks", side_effect=fake_blocks), \
+         patch("app.routers.booking.create_drive_time_blocks", side_effect=fake_blocks), \
          patch("app.services.calendar.CalendarService.create_event", return_value="evt-id"):
         db2 = Session()
         set_setting(db2, "google_refresh_token", "fake-token")
@@ -283,7 +283,7 @@ def test_first_group_showing_booking_still_creates_drive_time_blocks():
     mock_settings.from_email = "test@example.com"
 
     with patch("app.routers.booking.get_settings", return_value=mock_settings), \
-         patch("app.routers.booking._create_drive_time_blocks", side_effect=fake_blocks), \
+         patch("app.routers.booking.create_drive_time_blocks", side_effect=fake_blocks), \
          patch("app.services.calendar.CalendarService.create_event", return_value="evt-id"):
         db2 = Session()
         set_setting(db2, "google_refresh_token", "fake-token")

--- a/tests/test_slots_route.py
+++ b/tests/test_slots_route.py
@@ -9,7 +9,7 @@ from app.database import Base, get_db
 from app.main import app
 from app.models import AppointmentType, AvailabilityRule
 from app.dependencies import set_setting
-from app.routers.slots import _compute_slots_for_type
+from app.services.slots import compute_slots_for_type
 
 
 def setup_db():
@@ -55,7 +55,7 @@ def setup_db():
 def test_slots_returns_html_for_valid_date():
     client, appt_id = setup_db()
     # 2025-03-03 is a Monday; mock utcnow to a time before the date so slots are not filtered
-    with patch("app.routers.slots.datetime") as mock_dt:
+    with patch("app.services.slots.datetime") as mock_dt:
         mock_dt.now.return_value = datetime(2025, 3, 1, 0, 0, 0, tzinfo=dt_timezone.utc)
         mock_dt.combine = datetime.combine
         response = client.get(f"/slots?type_id={appt_id}&date=2025-03-03")
@@ -67,7 +67,7 @@ def test_slots_returns_html_for_valid_date():
 def test_slots_returns_no_slots_for_wrong_day():
     client, appt_id = setup_db()
     # 2025-03-04 is a Tuesday — no rules for Tuesday
-    with patch("app.routers.slots.datetime") as mock_dt:
+    with patch("app.services.slots.datetime") as mock_dt:
         mock_dt.now.return_value = datetime(2025, 3, 1, 0, 0, 0, tzinfo=dt_timezone.utc)
         mock_dt.combine = datetime.combine
         response = client.get(f"/slots?type_id={appt_id}&date=2025-03-04")
@@ -86,7 +86,7 @@ def test_slots_invalid_type_returns_error():
 
 def test_slots_display_12_hour_format():
     client, appt_id = setup_db()
-    with patch("app.routers.slots.datetime") as mock_dt:
+    with patch("app.services.slots.datetime") as mock_dt:
         mock_dt.now.return_value = datetime(2025, 3, 1, 0, 0, 0, tzinfo=dt_timezone.utc)
         mock_dt.combine = datetime.combine
         response = client.get(f"/slots?type_id={appt_id}&date=2025-03-03")
@@ -115,8 +115,8 @@ def test_slots_applies_drive_time_when_enabled(client):
     db.add(appt)
     db.commit()
 
-    with patch("app.routers.slots.trim_windows_for_drive_time", return_value=[]) as mock_trim, \
-         patch("app.routers.slots._build_free_windows", return_value=[]):
+    with patch("app.services.slots.trim_windows_for_drive_time", return_value=[]) as mock_trim, \
+         patch("app.services.slots._build_free_windows", return_value=[]):
         resp = client.get(f"/slots?type_id={appt.id}&date=2025-03-03")
     mock_trim.assert_called_once()
 
@@ -144,9 +144,9 @@ def test_slots_calendar_window_filters_slots(client):
     mock_settings.google_client_secret = "fake-secret"
     mock_settings.google_redirect_uri = "http://localhost/callback"
 
-    with patch("app.routers.slots.CalendarService") as MockCal, \
-         patch("app.routers.slots.get_settings", return_value=mock_settings), \
-         patch("app.routers.slots.datetime") as mock_dt:
+    with patch("app.services.slots.build_calendar_service") as MockCal, \
+         patch("app.services.slots.get_settings", return_value=mock_settings), \
+         patch("app.services.slots.datetime") as mock_dt:
         MockCal.return_value.get_events_for_day.return_value = []  # No matching events
         MockCal.return_value.get_busy_intervals.return_value = []
         mock_dt.now.return_value = datetime(2030, 9, 1, 0, 0, 0, tzinfo=dt_timezone.utc)
@@ -190,9 +190,9 @@ def test_compute_slots_calendar_window_all_day_event_creates_window():
     mock_settings.google_client_secret = "fake-secret"
     mock_settings.google_redirect_uri = "http://localhost/callback"
 
-    with patch("app.routers.slots.get_settings", return_value=mock_settings), \
-         patch("app.routers.slots.CalendarService") as MockCal, \
-         patch("app.routers.slots.datetime") as mock_dt:
+    with patch("app.services.slots.get_settings", return_value=mock_settings), \
+         patch("app.services.slots.build_calendar_service") as MockCal, \
+         patch("app.services.slots.datetime") as mock_dt:
         MockCal.return_value.get_events_for_day.return_value = [
             {
                 "start": datetime(2030, 9, 16, 0, 0, 0),
@@ -204,7 +204,7 @@ def test_compute_slots_calendar_window_all_day_event_creates_window():
         MockCal.return_value.get_busy_intervals.return_value = []
         mock_dt.now.return_value = datetime(2030, 9, 1, 0, 0, 0, tzinfo=dt_timezone.utc)
         mock_dt.combine = datetime.combine
-        slots = _compute_slots_for_type(appt, target_date, db)
+        slots = compute_slots_for_type(appt, target_date, db)
 
     assert any(slot["display"] == "9:00 AM" for slot in slots)
     assert any(slot["display"] == "4:00 PM" for slot in slots)
@@ -245,14 +245,14 @@ def test_compute_slots_calendar_window_without_match_returns_no_slots():
     mock_settings.google_client_secret = "fake-secret"
     mock_settings.google_redirect_uri = "http://localhost/callback"
 
-    with patch("app.routers.slots.get_settings", return_value=mock_settings), \
-         patch("app.routers.slots.CalendarService") as MockCal, \
-         patch("app.routers.slots.datetime") as mock_dt:
+    with patch("app.services.slots.get_settings", return_value=mock_settings), \
+         patch("app.services.slots.build_calendar_service") as MockCal, \
+         patch("app.services.slots.datetime") as mock_dt:
         MockCal.return_value.get_events_for_day.return_value = []
         MockCal.return_value.get_busy_intervals.return_value = []
         mock_dt.now.return_value = datetime(2030, 9, 1, 0, 0, 0, tzinfo=dt_timezone.utc)
         mock_dt.combine = datetime.combine
-        slots = _compute_slots_for_type(appt, target_date, db)
+        slots = compute_slots_for_type(appt, target_date, db)
 
     assert slots == []
     db.close()
@@ -302,9 +302,9 @@ def test_slots_uses_destination_for_admin_initiated_type():
     app.dependency_overrides[get_db] = override
     client = TestClient(app)
 
-    with patch("app.routers.slots.datetime") as mock_dt, \
+    with patch("app.services.slots.datetime") as mock_dt, \
          patch("app.services.availability.get_drive_time", return_value=20), \
-         patch("app.routers.slots.trim_windows_for_drive_time", return_value=[(time(9, 0), time(17, 0))]) as mock_trim:
+         patch("app.services.slots.trim_windows_for_drive_time", return_value=[(time(9, 0), time(17, 0))]) as mock_trim:
         mock_dt.now.return_value = datetime(2025, 3, 1, 0, 0, 0, tzinfo=dt_timezone.utc)
         mock_dt.combine = datetime.combine
         resp = client.get(f"/slots?type_id={appt_id}&date=2025-03-03&destination=123+Main+St+Atlanta")


### PR DESCRIPTION
## Summary

Behavior-preserving code-quality pass from a full architecture review. The complete analysis (architecture breakdown, data flows, problem inventory, roadmap) is in the new `ARCHITECTURE_REVIEW.md` at the repo root.

**No functional changes.** Test suite is identical before and after: 163 passed, 17 skipped.

### What changed

- **Service-layer extraction** — business logic moves out of routers, which previously imported each other's private helpers:
  - `services/slots.py`: slot engine (`compute_slots_for_type`), plus `compute_inspection_slots` replacing the ~80-line near-duplicate in the admin inspection-slots endpoint
  - `services/scheduling.py`: `perform_reschedule`, `create_drive_time_blocks`, `delete_drive_time_events`, shared cancel cleanup
- **Single-point utilities** — `services/timeutils.py` for the UTC↔local conversion idiom (was hand-rolled inline in 12+ places), `build_calendar_service()` factory (was an 8× duplicated construction), shared Jinja env in `app/templating.py`, `get_email_config` / `get_conflict_calendars` settings helpers
- **Observability** — ~25 silent `except Exception: pass` blocks now log warnings with tracebacks. Failure *policy* is unchanged: calendar/email side effects remain non-fatal best-effort
- **Email service dedup** — one render-with-fallback helper, one send helper (was triplicated)
- **Indexes** — composite `bookings (status, start_datetime)` and `(appointment_type_id, status, start_datetime)`, added idempotently in `init_db()` for existing databases and in ORM metadata for fresh ones
- **Tests** — mock patch targets updated to the new module layout; assertions untouched

### Deliberately not done (would change behavior — see roadmap in `ARCHITECTURE_REVIEW.md`)

Busy-interval/webcal caching, transactional booking-race guard, async I/O conversion, Alembic migration, admin router split.

### Test plan

- [x] `pytest -q` — 163 passed, 17 skipped (identical to pre-refactor baseline on `master`)
- [x] App imports and registers all 46 routes

https://claude.ai/code/session_01XS9mnz82xDMeAXZC66GVW2

---
_Generated by [Claude Code](https://claude.ai/code/session_01XS9mnz82xDMeAXZC66GVW2)_