### PR TITLE
fix: admin settings showed Google Calendar as connected with a dead token

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -554,6 +554,10 @@ def admin_reschedule_booking(
 @router.get("/settings", response_class=HTMLResponse)
 def settings_page(request: Request, db: Session = Depends(get_db), _=AuthDep):
     dbs = load_db_settings(db, get_settings())
+    google_token_invalid = False
+    if dbs.google_refresh_token:
+        cal = build_calendar_service(get_settings())
+        google_token_invalid = cal.verify_refresh_token(dbs.google_refresh_token) is False
     return templates.TemplateResponse("admin/settings.html", {
         "request": request,
         "owner_name": dbs.owner_name,
@@ -565,6 +569,7 @@ def settings_page(request: Request, db: Session = Depends(get_db), _=AuthDep):
         "from_email": dbs.from_email,
         "contact_phone": dbs.contact_phone,
         "google_authorized": bool(dbs.google_refresh_token),
+        "google_token_invalid": google_token_invalid,
         "conflict_cals": dbs.conflict_calendars,
         "email_guest_confirmation": dbs.email_guest_confirmation,
         "email_admin_alert": dbs.email_admin_alert,

--- a/app/services/calendar.py
+++ b/app/services/calendar.py
@@ -2,6 +2,8 @@ import httpx
 from datetime import datetime
 from datetime import date as _date_type
 from datetime import timezone as _utc_tz
+from google.auth.exceptions import RefreshError
+from google.auth.transport.requests import Request as GoogleAuthRequest
 from google_auth_oauthlib.flow import Flow
 from googleapiclient.discovery import build
 from google.oauth2.credentials import Credentials
@@ -65,6 +67,30 @@ class CalendarService:
 
     def is_authorized(self, refresh_token: str) -> bool:
         return bool(refresh_token)
+
+    def verify_refresh_token(self, refresh_token: str) -> bool | None:
+        """Check whether Google still accepts the stored refresh token.
+
+        Returns True when a token refresh succeeds, False when Google
+        definitively rejects the grant (revoked/expired/invalid), and None
+        when validity could not be determined (e.g. network failure) so
+        callers do not report a working connection as broken.
+        """
+        creds = Credentials(
+            token=None,
+            refresh_token=refresh_token,
+            token_uri="https://oauth2.googleapis.com/token",
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            scopes=SCOPES,
+        )
+        try:
+            creds.refresh(GoogleAuthRequest())
+        except RefreshError:
+            return False
+        except Exception:
+            return None
+        return True
 
     def _build_service(self, refresh_token: str):
         creds = Credentials(

--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -44,7 +44,9 @@
 
 <div class="card" style="cursor:default;max-width:520px;">
   <h2 style="margin-bottom:.75rem;">Google Calendar</h2>
-  {% if google_authorized %}
+  {% if google_authorized and google_token_invalid %}
+  <p style="color:#dc2626;margin-bottom:.75rem;">&#9888; Connection broken — Google rejected the saved credentials (revoked or expired). Calendar availability and event creation are failing. Re-authorize below.</p>
+  {% elif google_authorized %}
   <p style="color:#059669;margin-bottom:.75rem;">&#10003; Connected</p>
   {% else %}
   <p style="color:#dc2626;margin-bottom:.75rem;">Not connected — calendar availability and event creation will be skipped.</p>

--- a/tests/test_google_status.py
+++ b/tests/test_google_status.py
@@ -1,0 +1,124 @@
+"""Settings page must report Google Calendar status from token *validity*,
+not mere token presence — a revoked refresh token previously showed Connected."""
+import os
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.database import Base, get_db
+from app.dependencies import require_admin, set_setting
+from app.main import app
+from app.services.calendar import CalendarService
+
+BROKEN_MARKER = "Connection broken"
+CONNECTED_MARKER = "Connected"
+
+
+@pytest.fixture(name="status_client")
+def status_client_fixture(tmp_path, monkeypatch):
+    monkeypatch.setenv("UPLOAD_DIR", str(tmp_path / "uploads"))
+    os.makedirs(tmp_path / "uploads", exist_ok=True)
+    from app.config import get_settings
+    get_settings.cache_clear()
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine)
+
+    def override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[require_admin] = lambda: True
+
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c, TestSession
+
+    app.dependency_overrides.clear()
+    get_settings.cache_clear()
+
+
+def _store_refresh_token(TestSession, value="some-stored-token"):
+    db = TestSession()
+    set_setting(db, "google_refresh_token", value)
+    db.close()
+
+
+def test_no_token_shows_not_connected(status_client):
+    client, _ = status_client
+    resp = client.get("/admin/settings")
+    assert resp.status_code == 200
+    assert "Not connected" in resp.text
+    assert BROKEN_MARKER not in resp.text
+
+
+def test_rejected_token_shows_broken_not_connected(status_client, monkeypatch):
+    client, TestSession = status_client
+    _store_refresh_token(TestSession)
+    monkeypatch.setattr(CalendarService, "verify_refresh_token", lambda self, token: False)
+
+    resp = client.get("/admin/settings")
+    assert resp.status_code == 200
+    assert BROKEN_MARKER in resp.text
+    assert "&#10003; Connected" not in resp.text
+
+
+def test_valid_token_shows_connected(status_client, monkeypatch):
+    client, TestSession = status_client
+    _store_refresh_token(TestSession)
+    monkeypatch.setattr(CalendarService, "verify_refresh_token", lambda self, token: True)
+
+    resp = client.get("/admin/settings")
+    assert resp.status_code == 200
+    assert CONNECTED_MARKER in resp.text
+    assert BROKEN_MARKER not in resp.text
+
+
+def test_unverifiable_token_still_shows_connected(status_client, monkeypatch):
+    """Network hiccups (verify returns None) must not flip the status to broken."""
+    client, TestSession = status_client
+    _store_refresh_token(TestSession)
+    monkeypatch.setattr(CalendarService, "verify_refresh_token", lambda self, token: None)
+
+    resp = client.get("/admin/settings")
+    assert resp.status_code == 200
+    assert CONNECTED_MARKER in resp.text
+    assert BROKEN_MARKER not in resp.text
+
+
+def test_verify_refresh_token_maps_google_responses(monkeypatch):
+    """Unit check of the mapping: refresh ok -> True, RefreshError -> False,
+    transport failure -> None."""
+    from google.auth.exceptions import RefreshError, TransportError
+
+    svc = CalendarService("cid", "csecret", "https://example.com/cb")
+
+    def _ok(self, request):
+        return None
+
+    def _rejected(self, request):
+        raise RefreshError("invalid_grant: Bad Request")
+
+    def _network_down(self, request):
+        raise TransportError("connection refused")
+
+    from google.oauth2.credentials import Credentials
+
+    monkeypatch.setattr(Credentials, "refresh", _ok)
+    assert svc.verify_refresh_token("tok") is True
+
+    monkeypatch.setattr(Credentials, "refresh", _rejected)
+    assert svc.verify_refresh_token("tok") is False
+
+    monkeypatch.setattr(Credentials, "refresh", _network_down)
+    assert svc.verify_refresh_token("tok") is None


### PR DESCRIPTION
## Problem
The admin settings page derived Google Calendar status from token *presence* (`bool(dbs.google_refresh_token)`). When the stored refresh token was revoked/expired, every freebusy call failed with `invalid_grant` — slots were offered without conflict checking — yet the page still showed **✓ Connected**.

## Fix
- `CalendarService.verify_refresh_token()` performs a real token refresh against Google: `True` on success, `False` when Google definitively rejects the grant, `None` when validity can't be determined (network failure) so transient errors don't flip a healthy status.
- `/admin/settings` calls it when a token exists and renders **⚠ Connection broken — re-authorize** only on definitive rejection.

## Tests
5 new tests in `tests/test_google_status.py` covering all four status states plus the RefreshError/TransportError mapping. Full suite: 184 passed, 17 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)