### PR TITLE
feat: email owner when Google rejects the calendar refresh token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,14 @@ Google requires an exact host/path match for OAuth redirect URIs. `https://previ
 - **Mobile booking UI** — responsive card layout: photo stacks above text on mobile (`flex-direction: column-reverse`); reduced header padding; full-width date picker on mobile
 - **Drive time block events** — when a booking is confirmed for an appointment type with `requires_drive_time=True`, creates "BLOCK - Drive Time for …" calendar events on the owner's calendar: one before the appointment (from preceding event location or `home_address` setting) and one after (to the next event's location), each within a ±1-hour window; implemented in `_create_drive_time_blocks()` in `app/routers/booking.py`
 - **Google Calendar reliability fixes (March 12, 2026)** — reconnect now persists the OAuth PKCE code verifier across `/admin/google/authorize` → `/admin/google/callback`; calendar-window mode now fails closed when enabled but no matching events exist, supports matching all-day events, and normalizes offset-aware `events.list()` timestamps to UTC before local conversion so local booking windows do not shift earlier or later
+- **Dead Google token detection (June 11, 2026)** — admin settings page verifies the refresh token with a real Google token-refresh call (`CalendarService.verify_refresh_token()`), showing "Connection broken — re-authorize" on definitive rejection (transient network errors never flip the status); the slot engine emails the owner once per failure episode when Google rejects the token (`_alert_if_token_dead()` in `app/services/slots.py`, flag `google_token_alert_sent` in settings, re-armed on reconnect)
+
+---
+
+## Known Non-obvious Invariants
+
+**A dead Google refresh token does not break booking — it silently disables conflict checking.**
+`/slots` fails open on Google freebusy errors (logged, but slots are still served), so guests can book over busy calendar times. Two guardrails exist: the admin settings page does a live token check on load, and the slot engine sends a one-time ops alert email when Google definitively rejects the token. Calendar-window mode is the exception — it fails closed (no matching events → no slots).
 
 ---
 

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -681,6 +681,7 @@ def google_callback(
     try:
         refresh_token = cal.exchange_code(code, code_verifier=code_verifier)
         set_setting(db, "google_refresh_token", refresh_token)
+        set_setting(db, "google_token_alert_sent", "")  # re-arm the dead-token ops alert
         _flash(request, "Google Calendar connected successfully.")
     except Exception as e:
         logger.warning("Google OAuth code exchange failed", exc_info=True)

--- a/app/services/email.py
+++ b/app/services/email.py
@@ -77,6 +77,22 @@ _CANCELLATION_DEFAULT = """\
 <p>Your <strong>{appt_type}</strong> on {date_time} has been cancelled.</p>
 <p>Please reach out to reschedule.</p>"""
 
+# Ops alert — not admin-editable like the templates above.
+_GOOGLE_TOKEN_ALERT = """\
+<h2 style="color:#dc2626;">Google Calendar connection is broken</h2>
+<p>Google rejected the saved Calendar credentials (the refresh token was revoked or expired).</p>
+<p><strong>Until you re-authorize, booking slots are offered without checking your
+calendar for conflicts</strong>, and new bookings will not create calendar events.</p>
+<p><a href="{settings_url}">Open admin settings to re-authorize Google Calendar</a></p>"""
+
+
+def send_google_token_alert(api_key: str, from_email: str, notify_email: str, settings_url: str):
+    _send(
+        api_key, from_email, notify_email,
+        subject="Action needed: Google Calendar disconnected — bookings are not conflict-checked",
+        html=_GOOGLE_TOKEN_ALERT.format(settings_url=settings_url),
+    )
+
 
 def send_guest_confirmation(
     api_key: str,

--- a/app/services/slots.py
+++ b/app/services/slots.py
@@ -13,11 +13,13 @@ import logging
 from datetime import date, datetime, time as time_type, timedelta, timezone as dt_timezone
 from urllib.parse import urlparse
 
+from google.auth.exceptions import RefreshError
 from sqlalchemy.orm import Session
 
 from app.config import get_settings
-from app.dependencies import load_db_settings
+from app.dependencies import get_setting, load_db_settings, set_setting
 from app.models import AppointmentType, AvailabilityRule, BlockedPeriod, Booking
+from app.services import email
 from app.services.availability import (
     _build_free_windows,
     filter_by_advance_notice,
@@ -30,6 +32,43 @@ from app.services.calendar import build_calendar_service, fetch_webcal_events
 from app.services.timeutils import local_day_bounds_utc, utc_to_local
 
 logger = logging.getLogger(__name__)
+
+GOOGLE_TOKEN_ALERT_FLAG = "google_token_alert_sent"
+
+
+def _admin_settings_url(settings) -> str:
+    parsed = urlparse(settings.google_redirect_uri)
+    if parsed.scheme and parsed.netloc:
+        return f"{parsed.scheme}://{parsed.netloc}/admin/settings"
+    return "/admin/settings"
+
+
+def _alert_if_token_dead(exc: Exception, db: Session, dbs) -> None:
+    """Email the owner when Google definitively rejects the refresh token.
+
+    A dead token does not break booking — slots are served without conflict
+    checking, which the owner cannot otherwise see. Edge-triggered: one email
+    per failure episode (flag re-armed on Google reconnect). The flag is only
+    set after a successful send so a failed/unconfigured email retries later.
+    """
+    if not isinstance(exc, RefreshError):
+        return
+    if get_setting(db, GOOGLE_TOKEN_ALERT_FLAG, ""):
+        return
+    if not (dbs.resend_api_key and dbs.notify_email):
+        logger.warning("Google refresh token rejected but no alert email configured")
+        return
+    try:
+        email.send_google_token_alert(
+            api_key=dbs.resend_api_key,
+            from_email=dbs.from_email,
+            notify_email=dbs.notify_email,
+            settings_url=_admin_settings_url(get_settings()),
+        )
+    except Exception:
+        logger.warning("Failed to send Google token alert email", exc_info=True)
+        return
+    set_setting(db, GOOGLE_TOKEN_ALERT_FLAG, datetime.utcnow().isoformat())
 
 
 def _cache_ttl(settings) -> int:
@@ -152,8 +191,9 @@ def compute_slots_for_type(
                         window_intervals.append((window_start, window_end))
                     else:
                         busy_intervals.append((local_start, local_end))
-            except Exception:
+            except Exception as exc:
                 logger.warning("Calendar-window event fetch failed for calendar %s", window_cal_id, exc_info=True)
+                _alert_if_token_dead(exc, db, dbs)
 
         if google_ids_for_freebusy:
             freebusy_ids = sorted(google_ids_for_freebusy)
@@ -167,8 +207,9 @@ def compute_slots_for_type(
                     (utc_to_local(utc_start, tz), utc_to_local(utc_end, tz))
                     for utc_start, utc_end in utc_busy
                 )
-            except Exception:
+            except Exception as exc:
                 logger.warning("Google freebusy query failed", exc_info=True)
+                _alert_if_token_dead(exc, db, dbs)
 
         if appt_type.requires_drive_time and effective_location:
             try:
@@ -178,8 +219,9 @@ def compute_slots_for_type(
                     ttl,
                 )
                 local_day_events.extend(_localize_event(ev, tz) for ev in day_events_utc)
-            except Exception:
+            except Exception as exc:
                 logger.warning("Drive-time day-event fetch failed", exc_info=True)
+                _alert_if_token_dead(exc, db, dbs)
 
     for webcal_url in webcal_urls:
         try:
@@ -277,8 +319,9 @@ def compute_inspection_slots(
                 (utc_to_local(utc_start, tz), utc_to_local(utc_end, tz))
                 for utc_start, utc_end in utc_busy
             )
-        except Exception:
+        except Exception as exc:
             logger.warning("Google freebusy query failed", exc_info=True)
+            _alert_if_token_dead(exc, db, dbs)
 
         if destination:
             try:
@@ -288,8 +331,9 @@ def compute_inspection_slots(
                     ttl,
                 )
                 local_day_events.extend(_localize_event(ev, tz) for ev in day_events_utc)
-            except Exception:
+            except Exception as exc:
                 logger.warning("Drive-time day-event fetch failed", exc_info=True)
+                _alert_if_token_dead(exc, db, dbs)
 
     rules = db.query(AvailabilityRule).filter_by(active=True).all()
     blocked = db.query(BlockedPeriod).all()

--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -74,7 +74,7 @@ def test_google_callback_passes_stored_code_verifier_to_exchange():
         "auth-code",
         code_verifier="verifier-123",
     )
-    mock_set_setting.assert_called_once_with(db, "google_refresh_token", "refresh-token")
+    mock_set_setting.assert_any_call(db, "google_refresh_token", "refresh-token")
     assert "oauth_state" not in request.session
     assert "oauth_code_verifier" not in request.session
     assert response.status_code == 302

--- a/tests/test_google_token_alert.py
+++ b/tests/test_google_token_alert.py
@@ -1,0 +1,152 @@
+"""A dead Google refresh token silently disables conflict checking on /slots.
+The owner must be emailed once per failure episode (edge-triggered), re-armed
+when Google Calendar is reconnected."""
+from datetime import date as date_type
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.auth.exceptions import RefreshError
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.config import Settings
+from app.database import Base
+from app.dependencies import get_setting, set_setting
+from app.models import AppointmentType
+from app.services.slots import compute_slots_for_type
+
+
+def _setup_db(with_email_config=True):
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    db = Session()
+    appt = AppointmentType(
+        name="Call", duration_minutes=30, buffer_before_minutes=0,
+        buffer_after_minutes=0, calendar_id="primary", active=True,
+        color="#fff", description="",
+    )
+    appt._custom_fields = "[]"
+    db.add(appt)
+    set_setting(db, "google_refresh_token", "fake-token")
+    set_setting(db, "timezone", "UTC")
+    if with_email_config:
+        set_setting(db, "resend_api_key", "re_fake")
+        set_setting(db, "notify_email", "owner@example.com")
+        set_setting(db, "from_email", "bookings@example.com")
+    db.commit()
+    return db, appt
+
+
+def _settings() -> Settings:
+    return Settings(
+        google_client_id="fake-id",
+        google_client_secret="fake-secret",
+        google_redirect_uri="https://booking.example.com/admin/google/callback",
+        slots_cache_ttl_seconds=0,
+    )
+
+
+def _compute_with_dead_token(db, appt, target, mock_alert_target):
+    mock_cal = MagicMock()
+    mock_cal.get_busy_intervals.side_effect = RefreshError("invalid_grant: Bad Request")
+    with patch("app.services.slots.get_settings", return_value=_settings()), \
+         patch("app.services.slots.build_calendar_service", return_value=mock_cal), \
+         patch(mock_alert_target) as mock_alert:
+        compute_slots_for_type(appt, target, db)
+        return mock_alert
+
+
+ALERT_TARGET = "app.services.slots.email.send_google_token_alert"
+
+
+def test_refresh_error_alerts_admin_once_per_episode():
+    db, appt = _setup_db()
+    mock_cal = MagicMock()
+    mock_cal.get_busy_intervals.side_effect = RefreshError("invalid_grant: Bad Request")
+    with patch("app.services.slots.get_settings", return_value=_settings()), \
+         patch("app.services.slots.build_calendar_service", return_value=mock_cal), \
+         patch(ALERT_TARGET) as mock_alert:
+        compute_slots_for_type(appt, date_type(2030, 9, 16), db)
+        compute_slots_for_type(appt, date_type(2030, 9, 17), db)
+
+    mock_alert.assert_called_once()
+    kwargs = mock_alert.call_args.kwargs
+    assert kwargs["notify_email"] == "owner@example.com"
+    assert kwargs["settings_url"] == "https://booking.example.com/admin/settings"
+    assert get_setting(db, "google_token_alert_sent", "") != ""
+    db.close()
+
+
+def test_generic_google_failure_does_not_alert():
+    db, appt = _setup_db()
+    mock_cal = MagicMock()
+    mock_cal.get_busy_intervals.side_effect = ConnectionError("network down")
+    with patch("app.services.slots.get_settings", return_value=_settings()), \
+         patch("app.services.slots.build_calendar_service", return_value=mock_cal), \
+         patch(ALERT_TARGET) as mock_alert:
+        compute_slots_for_type(appt, date_type(2030, 9, 16), db)
+
+    mock_alert.assert_not_called()
+    assert get_setting(db, "google_token_alert_sent", "") == ""
+    db.close()
+
+
+def test_no_resend_config_skips_alert_without_arming_flag():
+    """Without email config nothing can be sent — the flag must stay clear so
+    the alert still fires once Resend is configured."""
+    db, appt = _setup_db(with_email_config=False)
+    mock_cal = MagicMock()
+    mock_cal.get_busy_intervals.side_effect = RefreshError("invalid_grant")
+    with patch("app.services.slots.get_settings", return_value=_settings()), \
+         patch("app.services.slots.build_calendar_service", return_value=mock_cal), \
+         patch(ALERT_TARGET) as mock_alert:
+        compute_slots_for_type(appt, date_type(2030, 9, 16), db)
+
+    mock_alert.assert_not_called()
+    assert get_setting(db, "google_token_alert_sent", "") == ""
+    db.close()
+
+
+def test_failed_alert_send_does_not_arm_flag():
+    """If the alert email itself fails, the flag must stay clear for a retry —
+    and the failure must not break slot computation."""
+    db, appt = _setup_db()
+    mock_cal = MagicMock()
+    mock_cal.get_busy_intervals.side_effect = RefreshError("invalid_grant")
+    with patch("app.services.slots.get_settings", return_value=_settings()), \
+         patch("app.services.slots.build_calendar_service", return_value=mock_cal), \
+         patch(ALERT_TARGET, side_effect=RuntimeError("resend 500")):
+        slots = compute_slots_for_type(appt, date_type(2030, 9, 16), db)
+
+    assert isinstance(slots, list)
+    assert get_setting(db, "google_token_alert_sent", "") == ""
+    db.close()
+
+
+def test_reconnect_rearms_alert():
+    """A successful Google reconnect clears the sent-flag so the next failure
+    episode alerts again."""
+    import unittest.mock
+    from app.routers.admin import google_callback
+
+    request = SimpleNamespace(
+        session={"oauth_state": "state-123", "oauth_code_verifier": "v"},
+        query_params={"state": "state-123"},
+    )
+    db = unittest.mock.MagicMock()
+    with unittest.mock.patch("app.routers.admin.get_settings"), \
+         unittest.mock.patch("app.routers.admin.build_calendar_service") as MockCal, \
+         unittest.mock.patch("app.routers.admin.set_setting") as mock_set_setting:
+        MockCal.return_value.exchange_code.return_value = "new-token"
+        google_callback(request, code="auth-code", db=db, _=True)
+
+    mock_set_setting.assert_any_call(db, "google_refresh_token", "new-token")
+    mock_set_setting.assert_any_call(db, "google_token_alert_sent", "")
+    db.close()


### PR DESCRIPTION
## Problem
A dead Google refresh token doesn't break booking — `/slots` fails open and serves slots **without conflict checking**. PR #25 made the settings page detect this, but only when visited. The owner found out by accident.

## Fix
The slot engine now emails the owner the first time any Google Calendar fetch fails with `RefreshError` (definitive token rejection — revoked/expired):

- **Edge-triggered, can't spam**: one email per failure episode, tracked via the `google_token_alert_sent` setting; re-armed when Google Calendar is reconnected via `/admin/google/callback`.
- **Reliable delivery**: the flag is set only after a successful send, so a failed or unconfigured Resend setup retries on a later request instead of silently swallowing the alert.
- **No false alarms**: generic network failures never trigger it — only `RefreshError`.
- Wired into all five Google fetch sites in the slot engine (freebusy, calendar-window events, drive-time day events, both public and inspection flows).

Also documents the fail-open invariant in CLAUDE.md.

## Tests
5 new tests in `tests/test_google_token_alert.py` (alert-once, no-alert-on-network-error, unconfigured-email keeps flag clear, failed-send retries, reconnect re-arms). One existing callback test assertion updated for the intentional second `set_setting` call. Full suite: 189 passed, 17 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)