### PR TITLE
feat: expose health endpoint at /api/health

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -53,5 +53,6 @@ async def admin_not_authenticated_handler(request, exc):
 
 
 @app.get("/health")
+@app.get("/api/health")
 def health_check():
     return {"status": "ok"}

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -4,6 +4,12 @@ def test_health_check(client):
     assert response.json() == {"status": "ok"}
 
 
+def test_api_health_check(client):
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
 def test_security_headers_present(client):
     resp = client.get("/health")
     assert resp.headers.get("x-frame-options") == "DENY"


### PR DESCRIPTION
## Gap

The app serves its health response at `/health` but **not** at `/api/health`. Verified live (2026-06-26): `GET /health` → 200, `GET /api/health` → 404.

Devon's project standard for **single-container apps** is to expose the health check at `/api/health`. This app (Flavor A, single container, port 8000) was out of compliance, so the Coolify health check couldn't be pointed at the standard path.

## Change

Add `/api/health` as a **parallel route on the existing `health_check` handler** via a stacked decorator in `app/main.py` — it reuses the exact same logic and response. `/health` is left fully intact and continues to work.

```python
@app.get("/health")
@app.get("/api/health")
def health_check():
    return {"status": "ok"}
```

Both paths return `200 {"status": "ok"}` and carry the same security response headers (applied by the global middleware).

## Tests

Extended `tests/test_health.py` with `test_api_health_check` (asserts `/api/health` → 200 + `{"status": "ok"}`), mirroring the existing `/health` test. Full suite: **190 passed, 17 skipped**.

## Standard

Single-container apps expose `/api/health` (per the Health Checks standard). This brings BookingAssistant into compliance.

## Note

After this merges and deploys, the infra drift auto-remediation will enable the Coolify health check against `/api/health` automatically — no manual Coolify config change is needed as part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)