### PR TITLE
ci: add conformance runner (sandboxed brief → PR workflow)

### DIFF
--- a/.github/workflows/conformance-runner.yml
+++ b/.github/workflows/conformance-runner.yml
@@ -1,0 +1,76 @@
+name: Conformance Runner (brief → PR)
+
+# Sandboxed "brief → PR" runner for the app-conformance handoff system (Phase 2).
+# Fired manually or via the GitHub API (workflow_dispatch). Claude makes ONLY the
+# mechanical change the brief specifies, in a tool-scoped ephemeral container, and the
+# workflow opens a PR against the target branch for a human to review and merge.
+#
+# It NEVER merges and NEVER deploys — it always ends at a PR. The ephemeral runner +
+# the repo-scoped Claude GitHub App + the --allowedTools list are the security boundary:
+# Claude can edit this repo's files and nothing else (no infra, no secrets beyond what's
+# injected here, no external network via WebFetch/WebSearch).
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "The handoff brief — exactly what to change and how to verify it"
+        required: true
+        type: string
+      base_branch:
+        description: "Branch the fix targets / PR base (e.g. master, preview)"
+        required: true
+        default: "master"
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  conformance-fix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base_branch }}
+          fetch-depth: 0
+
+      - name: Claude makes the change (tool-scoped; edits only, no commit/push)
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--allowedTools Read,Edit,Bash,Glob --max-turns 12"
+          prompt: |
+            ${{ inputs.task }}
+
+            STRICT RULES for this run (non-negotiable):
+            - Make ONLY the change described above. Keep all existing behavior working.
+            - Do NOT git commit, git push, create a branch, or open a PR. Leave your edits
+              UNCOMMITTED in the working tree — the workflow opens the PR for you.
+            - Do NOT touch secrets, .env files, CI/workflow config, or anything outside the change.
+            - If the change is larger, trickier, or less certain than the brief implies, STOP
+              and explain what you found instead of guessing.
+
+      - name: Open PR against the target branch
+        uses: peter-evans/create-pull-request@v7
+        with:
+          base: ${{ inputs.base_branch }}
+          branch: conformance/run-${{ github.run_id }}
+          delete-branch: true
+          title: "conformance: automated app-conformance fix"
+          commit-message: "conformance: automated fix via brief→PR runner"
+          body: |
+            Automated by the conformance runner (Phase 2). **Review and merge on your own timing — this never auto-merges and never deploys.**
+
+            **Brief given to the agent:**
+
+            ```
+            ${{ inputs.task }}
+            ```
+
+            ---
+            ⚠️ **Landmine glance:** scan the diff for anything irreversible — migrations, deletions,
+            CI/secret changes, infra touches. For a mechanical route/flag change the risk surface
+            should be ~nil. The repo's normal CI runs the tests on this PR.


### PR DESCRIPTION
**Phase 2 of the app-conformance handoff system** — the sandboxed "brief → PR" runner.

## What it does
A `workflow_dispatch` job that takes a **handoff brief** + a **target branch**, lets Claude make *only* that mechanical change in a **tool-scoped ephemeral container**, and opens a PR against the target branch. **Never merges, never deploys — always ends at a PR you approve.**

- **Sandbox = security boundary:** `--allowedTools Read,Edit,Bash,Glob`, the repo-scoped Claude GitHub App, and the ephemeral runner mean Claude can edit *this repo* and nothing else (no infra, no secrets beyond the injected `ANTHROPIC_API_KEY`, no external fetch).
- Claude edits only (no commit/push); `peter-evans/create-pull-request` opens the PR against `base_branch` on a fresh branch.

## Why merge this first
`workflow_dispatch` can only fire a workflow that exists **on the default branch**. So this lands on `master` first; then we dispatch it with `base_branch=preview` and `task=`"bring /api/health to preview" as the first real test → it produces a PR against `preview` you review.

## ⚠️ This is the empirical-validation step
The one thing we couldn't verify without running it: whether `claude-code-action@v1` behaves cleanly headless on `workflow_dispatch` and leaves edits uncommitted for `peter-evans` to PR. The first dispatch validates that. If the action does its own git/PR or needs Bash-less edits, it's a small tweak (or the Agent-SDK-in-a-job fallback). Merging the workflow is safe regardless — it does nothing until dispatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jDsNW4DWScoKssXoTkFiX