### PR TITLE
ci(conformance-runner): add id-token: write for claude-code-action OIDC

### DIFF
--- a/.github/workflows/conformance-runner.yml
+++ b/.github/workflows/conformance-runner.yml
@@ -26,6 +26,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write   # claude-code-action mints its GitHub App token via OIDC
 
 jobs:
   conformance-fix:


### PR DESCRIPTION
First test dispatch of the conformance runner failed with:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

`claude-code-action@v1` mints its GitHub App installation token via OIDC, so the job needs `id-token: write`. One-line permission add — found empirically on the first run (everything else worked: dispatch fired, container span up, checkout ✓, the action launched).

Merge this and I'll re-fire the booking-preview test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jDsNW4DWScoKssXoTkFiX