### PR TITLE
ci(conformance-runner): request review + assign so bot PRs reach the human

### DIFF
--- a/.github/workflows/conformance-runner.yml
+++ b/.github/workflows/conformance-runner.yml
@@ -60,6 +60,11 @@ jobs:
           base: ${{ inputs.base_branch }}
           branch: conformance/run-${{ github.run_id }}
           delete-branch: true
+          # Route the bot-authored PR TO the human: request review + assign, so it surfaces in
+          # the GitHub app's "Review requested" / "Assigned" filters (a bot PR otherwise mentions
+          # nobody and is invisible there). Override via inputs later when generalizing per-repo.
+          reviewers: AlobarQuest
+          assignees: AlobarQuest
           title: "conformance: automated app-conformance fix"
           commit-message: "conformance: automated fix via brief→PR runner"
           body: |


### PR DESCRIPTION
**The gap:** the runner's first successful PR (#30) showed on the web but **not in Devon's GitHub app** — because a bot-authored PR mentions/assigns nobody, so it misses every default app filter (review-requested / assigned / mentioned). That quietly breaks the human-merge loop: PRs the agent opens "for you to review on your timing" never reach you.

**Fix:** add `reviewers: AlobarQuest` + `assignees: AlobarQuest` to the create-PR step, so every conformance PR lands in your "Review requested" and "Assigned" filters with a notification.

Merge this (workflow must be on `master` to dispatch) and I'll re-fire to confirm the next bot PR actually surfaces in your app. Bakes the fix in before the runner generalizes to other repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jDsNW4DWScoKssXoTkFiX